### PR TITLE
Update dependencies & gradle

### DIFF
--- a/app/and_res_guard.gradle
+++ b/app/and_res_guard.gradle
@@ -24,7 +24,7 @@ andResGuard {
             "*.webp"
     ]
     sevenzip {
-        artifact = 'com.tencent.mm:SevenZip:1.2.20'
+        artifact = 'com.tencent.mm:SevenZip:1.2.21'
         //path = "/usr/local/bin/7za"
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,11 +133,11 @@ configurations.all {
 }
 
 val grpcVersion by extra("1.37.0")
-val protocVersion by extra("3.15.6")
+val protocVersion by extra("3.15.8")
 
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3-native-mt")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3")
 
     implementation("com.absinthe.libraries.me:me:1.0.6")
     implementation("com.absinthe.libraries.utils:utils:1.2.0")
@@ -146,7 +146,7 @@ dependencies {
     implementation("com.microsoft.appcenter:appcenter-analytics:${appCenterSdkVersion}")
     implementation("com.microsoft.appcenter:appcenter-crashes:${appCenterSdkVersion}")
 
-    implementation("androidx.fragment:fragment-ktx:1.3.2")
+    implementation("androidx.fragment:fragment-ktx:1.3.3")
     implementation("androidx.activity:activity-ktx:1.2.2")
     // Lifecycle
     val lifecycleVersion = "2.3.1"
@@ -156,7 +156,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-process:$lifecycleVersion")
 
     // Room components
-    val roomVersion = "2.2.6"
+    val roomVersion = "2.3.0"
     implementation("androidx.room:room-runtime:$roomVersion")
     implementation("androidx.room:room-ktx:$roomVersion")
     kapt("androidx.room:room-compiler:$roomVersion")
@@ -167,14 +167,14 @@ dependencies {
     implementation("androidx.preference:preference-ktx:1.1.1")
     implementation("androidx.viewpager2:viewpager2:1.1.0-alpha01")
     implementation("androidx.recyclerview:recyclerview:1.2.0")
-    implementation("androidx.core:core-ktx:1.6.0-alpha01")
+    implementation("androidx.core:core-ktx:1.6.0-alpha02")
 
     implementation("com.google.android.material:material:1.3.0")
     implementation("com.github.CymChad:BaseRecyclerViewAdapterHelper:3.0.6")
     implementation("com.drakeet.about:about:2.4.1")
     implementation("com.drakeet.multitype:multitype:4.2.0")
     implementation("com.airbnb.android:lottie:3.7.0")
-    implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
+    implementation("com.github.PhilJay:MPAndroidChart:3.1.0")
     implementation("com.jonathanfinerty.once:once:1.3.0")
     implementation("net.dongliu:apk-parser:2.6.10")
     implementation("io.coil-kt:coil:1.2.0")
@@ -189,7 +189,7 @@ dependencies {
     implementation ("dev.rikka.rikkax.appcompat:appcompat:1.2.0-rc01")
     implementation("dev.rikka.rikkax.core:core:1.3.2")
     implementation("dev.rikka.rikkax.material:material:1.6.4")
-    implementation("dev.rikka.rikkax.recyclerview:recyclerview-ktx:1.2.0")
+    implementation("dev.rikka.rikkax.recyclerview:recyclerview-ktx:1.2.1")
     implementation("dev.rikka.rikkax.widget:borderview:1.0.1")
     implementation("dev.rikka.rikkax.preference:simplemenu-preference:1.0.2")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,9 +9,8 @@ plugins {
     id("kotlin-parcelize")
     id("com.google.protobuf")
 }
-apply {
-    from("and_res_guard.gradle")
-}
+
+apply("and_res_guard.gradle")
 
 android {
     compileSdkVersion(30)
@@ -29,15 +28,16 @@ android {
         versionName = "${baseVersionName}.${gitCommitId}"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         resConfigs("en", "zh-rCN", "zh-rTW", "ru", "uk-rUA")
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments["room.incremental"] = "true"
-            }
-        }
     }
 
     buildFeatures {
         viewBinding = true
+    }
+
+    kapt {
+        arguments {
+            arg("room.incremental", "true")
+        }
     }
 
     buildTypes {
@@ -47,39 +47,31 @@ android {
         getByName("release") {
             isMinifyEnabled = true
             isShrinkResources = true
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 
     // To inline the bytecode built with JVM target 1.8 into
     // bytecode that is being built with JVM target 1.6. (e.g. navArgs)
 
-    sourceSets {
-        getByName("main").java.apply {
-            srcDirs("src/main/kotlin")
-            srcDirs("src/main/java")
-            srcDirs("src/main/proto")
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
+    sourceSets["main"].java.srcDirs("src/main/kotlin")
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
         freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-XXLanguage:+InlineClasses")
     }
 
-    packagingOptions {
-        excludes += "META-INF/**"
-        excludes += "okhttp3/**"
-        excludes += "kotlin/**"
-        excludes += "org/**"
-        excludes += "**.properties"
-        excludes += "**.bin"
-    }
+    packagingOptions.excludes += setOf(
+        "META-INF/**",
+        "okhttp3/**",
+        "kotlin/**",
+        "org/**",
+        "**.properties",
+        "**.bin"
+    )
 
     dependenciesInfo.includeInApk = false
 
@@ -186,7 +178,7 @@ dependencies {
     implementation("com.google.code.gson:gson:2.8.6")
     implementation("com.google.protobuf:protobuf-javalite:$protocVersion")
 
-    implementation ("dev.rikka.rikkax.appcompat:appcompat:1.2.0-rc01")
+    implementation("dev.rikka.rikkax.appcompat:appcompat:1.2.0-rc01")
     implementation("dev.rikka.rikkax.core:core:1.3.2")
     implementation("dev.rikka.rikkax.material:material:1.6.4")
     implementation("dev.rikka.rikkax.recyclerview:recyclerview-ktx:1.2.1")
@@ -230,7 +222,7 @@ protobuf {
                     }
                 }
 
-                it.plugins{
+                it.plugins {
                     create("grpc") {
                         option("lite")
                     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
-        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.0-rc01")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,8 +12,8 @@ buildscript {
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath("com.tencent.mm:AndResGuard-gradle-plugin:1.2.20") // Resource obfuscate
-        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.13")
+        classpath("com.tencent.mm:AndResGuard-gradle-plugin:1.2.21") // Resource obfuscate
+        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.15")
     }
 }
 

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -54,13 +54,13 @@ android {
 
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3-native-mt")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3")
 
     implementation("com.absinthe.libraries.me:me:1.0.6")
-    implementation("com.absinthe.libraries.utils:utils:1.1.5")
+    implementation("com.absinthe.libraries.utils:utils:1.2.0")
 
     implementation("androidx.appcompat:appcompat:1.2.0")
-    implementation("androidx.core:core-ktx:1.6.0-alpha01")
+    implementation("androidx.core:core-ktx:1.6.0-alpha02")
 
     testImplementation("junit:junit:4.13.2")
     debugImplementation("com.squareup.leakcanary:leakcanary-android:2.7")

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -23,33 +23,26 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 
     // To inline the bytecode built with JVM target 1.8 into
     // bytecode that is being built with JVM target 1.6. (e.g. navArgs)
 
-    sourceSets {
-        getByName("main").java.apply {
-            srcDirs("src/main/kotlin")
-            srcDirs("src/main/java")
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
+    sourceSets["main"].java.srcDirs("src/main/kotlin")
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
         freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-XXLanguage:+InlineClasses")
     }
 
-    packagingOptions {
-        exclude("META-INF/atomicfu.kotlin_module")
-    }
+    packagingOptions.excludes += setOf(
+        "META-INF/atomicfu.kotlin_module"
+    )
 }
 
 dependencies {


### PR DESCRIPTION
- 依赖升级
- aptOptions 挪到 kaptOptions 下面
- Java 和 Protobuf 的 `sourceset` 目录不需要显式声明，在 AGP 7.0 之后默认支持 kotlin 作为目录，那时候就也不需要声明了
- AGP 4.2 之后编译默认的 Java 版本就是 1.8，不需要显式声明
- `packagingOptions.excludes` 使用集合写法
- `buildscript` 中使用 `gradlePluginPortal` 替换 `mavenCentral` 和 `jCenter`