### PR TITLE
Update dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,13 +55,9 @@ android {
         }
     }
 
-    // To inline the bytecode built with JVM target 1.8 into
-    // bytecode that is being built with JVM target 1.6. (e.g. navArgs)
-
     sourceSets["main"].java.srcDirs("src/main/kotlin")
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
         freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-XXLanguage:+InlineClasses")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.0-rc01")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath("com.tencent.mm:AndResGuard-gradle-plugin:1.2.21") // Resource obfuscate
-        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.15")
+        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.16")
     }
 }
 

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -30,13 +30,9 @@ android {
         }
     }
 
-    // To inline the bytecode built with JVM target 1.8 into
-    // bytecode that is being built with JVM target 1.6. (e.g. navArgs)
-
     sourceSets["main"].java.srcDirs("src/main/kotlin")
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
         freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-XXLanguage:+InlineClasses")
     }
 


### PR DESCRIPTION
- Kotlin 升级 1.5.0 啦，默认的 `jvmTarget` 是 1.8 了，不再需要显式声明

![image](https://user-images.githubusercontent.com/10363352/116175540-17ddee80-a743-11eb-80e9-e8cdc456babb.png)
