### PR TITLE
Replace Okhttp call functions with suspend functions

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/api/ApiManager.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/api/ApiManager.kt
@@ -32,9 +32,9 @@ object ApiManager {
 
     private val retrofit by lazy {
         val okhttpBuilder = OkHttpClient.Builder()
-            .connectTimeout(30 * 1000, TimeUnit.MILLISECONDS)
-            .readTimeout(30 * 1000, TimeUnit.MILLISECONDS)
-            .writeTimeout(30 * 1000, TimeUnit.MILLISECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
         Retrofit.Builder()
             .addConverterFactory(GsonConverterFactory.create())
             .client(okhttpBuilder.build())

--- a/app/src/main/kotlin/com/absinthe/libchecker/api/request/CloudRuleBundleRequest.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/api/request/CloudRuleBundleRequest.kt
@@ -1,16 +1,11 @@
 package com.absinthe.libchecker.api.request
 
 import com.absinthe.libchecker.api.bean.CloudRuleInfo
-import okhttp3.ResponseBody
-import retrofit2.Call
 import retrofit2.http.GET
 
 const val VERSION = 3
 
 interface CloudRuleBundleRequest {
     @GET("cloud/md5/v$VERSION")
-    fun requestCloudRuleInfo(): Call<CloudRuleInfo>
-
-    @GET("cloud/rules/v$VERSION/rules.db")
-    fun requestRulesBundle(): Call<ResponseBody>
+    suspend fun requestCloudRuleInfo(): CloudRuleInfo?
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/api/request/LibDetailRequest.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/api/request/LibDetailRequest.kt
@@ -7,5 +7,5 @@ import retrofit2.http.Path
 
 interface LibDetailRequest {
     @GET("{categoryDir}/{libName}.json")
-    fun requestLibDetail(@Path("categoryDir") categoryDir: String, @Path("libName") libName: String): Call<LibDetailBean>
+    suspend fun requestLibDetail(@Path("categoryDir") categoryDir: String, @Path("libName") libName: String): LibDetailBean
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/CloudRulesDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/CloudRulesDialogFragment.kt
@@ -43,35 +43,27 @@ class CloudRulesDialogFragment : BaseBottomSheetViewDialogFragment<CloudRulesDia
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         lifecycleScope.launchWhenResumed {
-            request.requestCloudRuleInfo().enqueue(object : Callback<CloudRuleInfo> {
-                override fun onResponse(call: Call<CloudRuleInfo>, response: Response<CloudRuleInfo>) {
-                    val body = response.body()
-                    body?.let {
-                        lifecycleScope.launch(Dispatchers.Main) {
-                            try {
-                                root.cloudRulesContentView.localVersion.version.text = GlobalValues.localRulesVersion.toString()
-                                root.cloudRulesContentView.remoteVersion.version.text = it.version.toString()
-                                if (GlobalValues.localRulesVersion < it.version) {
-                                    root.cloudRulesContentView.updateButton.isEnabled = true
-                                }
-                                root.viewFlipper.displayedChild = 1
-                            } catch (e: Exception) {
-                                Timber.e(e)
-                                context?.let {
-                                    withContext(Dispatchers.Main) {
-                                        Toasty.show(it, R.string.toast_cloud_rules_update_error)
-                                    }
-                                }
-                            }
+            try {
+                request.requestCloudRuleInfo()?.let {
+                    try {
+                        root.cloudRulesContentView.localVersion.version.text =
+                            GlobalValues.localRulesVersion.toString()
+                        root.cloudRulesContentView.remoteVersion.version.text =
+                            it.version.toString()
+                        if (GlobalValues.localRulesVersion < it.version) {
+                            root.cloudRulesContentView.updateButton.isEnabled = true
+                        }
+                        root.viewFlipper.displayedChild = 1
+                    } catch (e: Exception) {
+                        Timber.e(e)
+                        context?.let { ct ->
+                            Toasty.show(ct, R.string.toast_cloud_rules_update_error)
                         }
                     }
                 }
-
-                override fun onFailure(call: Call<CloudRuleInfo>, t: Throwable) {
-                    Timber.e(t)
-                }
-
-            })
+            } catch (t: Throwable) {
+                Timber.e(t)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/DetailViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/DetailViewModel.kt
@@ -160,20 +160,12 @@ class DetailViewModel(application: Application) : AndroidViewModel(application) 
                 categoryDir += "/regex"
             }
 
-            val detail = request.requestLibDetail(categoryDir, libName)
-            detail.enqueue(object : Callback<LibDetailBean> {
-                override fun onFailure(call: Call<LibDetailBean>, t: Throwable) {
-                    Timber.e(t, "DetailViewModel")
-                    detailBean.value = null
-                }
-
-                override fun onResponse(
-                    call: Call<LibDetailBean>,
-                    response: Response<LibDetailBean>
-                ) {
-                    detailBean.value = response.body()
-                }
-            })
+            detailBean.value = try {
+                request.requestLibDetail(categoryDir, libName)
+            } catch (t: Throwable) {
+                Timber.e(t, "DetailViewModel")
+                null
+            }
         }
 
     private suspend fun getNativeChipList(info: ApplicationInfo, is32bit: Boolean, isApk: Boolean): List<LibStringItemChip> {


### PR DESCRIPTION
跑了一下代码发现有内存泄漏，如下图所示，查了之后发现 `DetailViewModel` 中的 `request.requestLibDetail()` 调用竟然是个 okhttp 的 call，用挂起函数代替应该就能解决问题了，顺便把 `CloudRulesDialogFragment` 中类似用法重构掉了。简单测试了一下好像没啥问题，你也试试看有没有功能错误。

![1](https://user-images.githubusercontent.com/10363352/125172910-d1027f80-e1ee-11eb-9b6c-7ccbae12b7fa.png)