### PR TITLE
Replace part of `lazy` with `unsafeLazy`

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
@@ -23,6 +23,7 @@ import com.absinthe.libchecker.recyclerview.adapter.snapshot.SnapshotAdapter
 import com.absinthe.libchecker.ui.detail.EXTRA_ENTITY
 import com.absinthe.libchecker.ui.detail.SnapshotDetailActivity
 import com.absinthe.libchecker.ui.fragment.snapshot.TimeNodeBottomSheetDialogFragment
+import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.view.snapshot.SnapshotEmptyView
 import com.absinthe.libchecker.viewmodel.SnapshotViewModel
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
@@ -38,7 +39,7 @@ class ComparisonActivity : BaseActivity() {
 
     private lateinit var binding: ActivityComparisonBinding
     private val viewModel by viewModels<SnapshotViewModel>()
-    private val adapter by lazy { SnapshotAdapter(lifecycleScope) }
+    private val adapter by unsafeLazy { SnapshotAdapter(lifecycleScope) }
     private var leftTimeStamp = 0L
     private var rightTimeStamp = 0L
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
@@ -17,6 +17,7 @@ import com.absinthe.libchecker.database.entity.TrackItem
 import com.absinthe.libchecker.databinding.ActivityTrackBinding
 import com.absinthe.libchecker.recyclerview.adapter.TrackAdapter
 import com.absinthe.libchecker.recyclerview.diff.TrackListDiff
+import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.view.detail.EmptyListView
 import com.absinthe.libchecker.view.snapshot.TrackItemView
 import com.absinthe.libchecker.view.snapshot.TrackLoadingView
@@ -30,7 +31,7 @@ class TrackActivity : BaseActivity(), SearchView.OnQueryTextListener {
 
     private lateinit var binding: ActivityTrackBinding
     private val repository = Repositories.lcRepository
-    private val adapter by lazy { TrackAdapter(lifecycleScope) }
+    private val adapter by unsafeLazy { TrackAdapter(lifecycleScope) }
     private val list = mutableListOf<TrackListItem>()
     private var menu: Menu? = null
     private var isListReady = false

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
@@ -39,6 +39,7 @@ import com.absinthe.libchecker.ui.main.EXTRA_REF_NAME
 import com.absinthe.libchecker.ui.main.EXTRA_REF_TYPE
 import com.absinthe.libchecker.utils.PackageUtils
 import com.absinthe.libchecker.utils.harmony.ApplicationDelegate
+import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.view.detail.CenterAlignImageSpan
 import com.absinthe.libchecker.viewmodel.DetailViewModel
 import com.google.android.material.tabs.TabLayout
@@ -58,12 +59,12 @@ const val EXTRA_DETAIL_BEAN = "EXTRA_DETAIL_BEAN"
 class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
 
     private lateinit var binding: ActivityAppDetailBinding
-    private val pkgName by lazy { intent.getStringExtra(EXTRA_PACKAGE_NAME) }
-    private val refName by lazy { intent.getStringExtra(EXTRA_REF_NAME) }
-    private val refType by lazy { intent.getIntExtra(EXTRA_REF_TYPE, ALL) }
-    private val extraBean by lazy { intent.getParcelableExtra(EXTRA_DETAIL_BEAN) as? DetailExtraBean }
-    private val viewModel by viewModels<DetailViewModel>()
-    private val bundleManager by lazy { ApplicationDelegate(this).iBundleManager }
+    private val pkgName by unsafeLazy { intent.getStringExtra(EXTRA_PACKAGE_NAME) }
+    private val refName by unsafeLazy { intent.getStringExtra(EXTRA_REF_NAME) }
+    private val refType by unsafeLazy { intent.getIntExtra(EXTRA_REF_TYPE, ALL) }
+    private val extraBean by unsafeLazy { intent.getParcelableExtra(EXTRA_DETAIL_BEAN) as? DetailExtraBean }
+    private val bundleManager by unsafeLazy { ApplicationDelegate(this).iBundleManager }
+    private val viewModel: DetailViewModel by viewModels()
 
     private var isHarmonyMode = false
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
@@ -34,6 +34,7 @@ import com.absinthe.libchecker.recyclerview.adapter.snapshot.node.SnapshotTitleN
 import com.absinthe.libchecker.ui.main.EXTRA_REF_NAME
 import com.absinthe.libchecker.ui.main.EXTRA_REF_TYPE
 import com.absinthe.libchecker.utils.PackageUtils
+import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.view.snapshot.SnapshotDetailDeletedView
 import com.absinthe.libchecker.view.snapshot.SnapshotDetailNewInstallView
 import com.absinthe.libchecker.view.snapshot.SnapshotEmptyView
@@ -54,9 +55,9 @@ class SnapshotDetailActivity : BaseActivity() {
     private lateinit var binding: ActivitySnapshotDetailBinding
     private lateinit var entity: SnapshotDiffItem
 
-    private val adapter by lazy { SnapshotDetailAdapter(lifecycleScope) }
+    private val adapter by unsafeLazy { SnapshotDetailAdapter(lifecycleScope) }
     private val viewModel by viewModels<SnapshotViewModel>()
-    private val _entity by lazy { intent.getSerializableExtra(EXTRA_ENTITY) as? SnapshotDiffItem }
+    private val _entity by unsafeLazy { intent.getSerializableExtra(EXTRA_ENTITY) as? SnapshotDiffItem }
 
     override fun setViewBinding(): ViewGroup {
         binding = ActivitySnapshotDetailBinding.inflate(layoutInflater)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseBottomSheetViewDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseBottomSheetViewDialogFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.FragmentManager
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.view.app.BottomSheetHeaderView
 import com.absinthe.libraries.utils.utils.UiUtils
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -18,7 +19,7 @@ abstract class BaseBottomSheetViewDialogFragment<T : View> : BottomSheetDialogFr
 
     private var _root: T? = null
     private var isHandlerActivated = false
-    private val behavior by lazy { BottomSheetBehavior.from(root.parent as View) }
+    private val behavior by unsafeLazy { BottomSheetBehavior.from(root.parent as View) }
     private val bottomSheetCallback = object : BottomSheetBehavior.BottomSheetCallback() {
         override fun onStateChanged(bottomSheet: View, newState: Int) {
             when (newState) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseDetailFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseDetailFragment.kt
@@ -18,6 +18,7 @@ import com.absinthe.libchecker.ui.fragment.detail.DetailFragmentManager
 import com.absinthe.libchecker.ui.fragment.detail.MODE_SORT_BY_SIZE
 import com.absinthe.libchecker.ui.fragment.detail.Sortable
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.view.detail.EmptyListView
 import com.absinthe.libchecker.viewmodel.DetailViewModel
 import kotlinx.coroutines.Dispatchers
@@ -39,8 +40,8 @@ abstract class BaseDetailFragment<T : ViewBinding>(layoutId: Int) : BaseFragment
     protected val viewModel by activityViewModels<DetailViewModel>()
     protected val packageName by lazy { arguments?.getString(EXTRA_PACKAGE_NAME).orEmpty() }
     protected val type by lazy { arguments?.getInt(EXTRA_TYPE) ?: NATIVE }
-    protected val adapter by lazy { LibStringAdapter(type) }
-    protected val emptyView by lazy { EmptyListView(requireContext()).apply {
+    protected val adapter by unsafeLazy { LibStringAdapter(type) }
+    protected val emptyView by unsafeLazy { EmptyListView(requireContext()).apply {
         layoutParams = android.widget.FrameLayout.LayoutParams(android.widget.FrameLayout.LayoutParams.MATCH_PARENT, android.widget.FrameLayout.LayoutParams.WRAP_CONTENT).also {
             it.gravity = android.view.Gravity.CENTER_HORIZONTAL
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/applist/AppListFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/applist/AppListFragment.kt
@@ -39,6 +39,7 @@ import com.absinthe.libchecker.utils.SPUtils
 import com.absinthe.libchecker.utils.Toasty
 import com.absinthe.libchecker.utils.doOnMainThreadIdle
 import com.absinthe.libchecker.utils.harmony.HarmonyOsUtil
+import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import com.microsoft.appcenter.analytics.Analytics
 import com.microsoft.appcenter.analytics.EventProperties
@@ -54,7 +55,7 @@ const val VF_INIT = 2
 
 class AppListFragment : BaseListControllerFragment<FragmentAppListBinding>(R.layout.fragment_app_list), SearchView.OnQueryTextListener {
 
-    private val mAdapter by lazy { AppAdapter(lifecycleScope) }
+    private val mAdapter by unsafeLazy { AppAdapter(lifecycleScope) }
     private var isFirstLaunch = !Once.beenDone(Once.THIS_APP_INSTALL, OnceTag.FIRST_LAUNCH)
     private var popup: PopupMenu? = null
 
@@ -165,7 +166,7 @@ class AppListFragment : BaseListControllerFragment<FragmentAppListBinding>(R.lay
                 it.label.contains(newText, ignoreCase = true) ||
                         it.packageName.contains(newText, ignoreCase = true)
             }.toMutableList()
-            
+
             if (HarmonyOsUtil.isHarmonyOs() && newText.contains("Harmony", true)) {
                 filter.addAll(allDatabaseItems.filter { it.variant == Constants.VARIANT_HAP })
             }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
@@ -35,6 +35,7 @@ import com.absinthe.libchecker.ui.fragment.BaseListControllerFragment
 import com.absinthe.libchecker.ui.main.MainActivity
 import com.absinthe.libchecker.ui.snapshot.AlbumActivity
 import com.absinthe.libchecker.utils.doOnMainThreadIdle
+import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.view.snapshot.SnapshotDashboardView
 import com.absinthe.libchecker.view.snapshot.SnapshotEmptyView
 import com.absinthe.libchecker.viewmodel.*
@@ -53,7 +54,7 @@ const val VF_LIST = 1
 class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(R.layout.fragment_snapshot) {
 
     private val viewModel by activityViewModels<SnapshotViewModel>()
-    private val adapter by lazy { SnapshotAdapter(lifecycleScope) }
+    private val adapter by unsafeLazy { SnapshotAdapter(lifecycleScope) }
     private var isSnapshotDatabaseItemsReady = false
     private var isApplicationInfoItemsReady = false
     private var dropPrevious = false

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
@@ -20,6 +20,7 @@ import com.absinthe.libchecker.ui.detail.AppDetailActivity
 import com.absinthe.libchecker.ui.detail.EXTRA_DETAIL_BEAN
 import com.absinthe.libchecker.ui.detail.EXTRA_PACKAGE_NAME
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.viewmodel.LibReferenceViewModel
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import kotlinx.coroutines.Dispatchers
@@ -34,7 +35,7 @@ const val EXTRA_REF_TYPE = "REF_TYPE"
 class LibReferenceActivity : BaseActivity() {
 
     private lateinit var binding: ActivityLibReferenceBinding
-    private val adapter by lazy { AppAdapter(lifecycleScope) }
+    private val adapter by unsafeLazy { AppAdapter(lifecycleScope) }
     private val viewModel by viewModels<LibReferenceViewModel>()
     private val refName by lazy { intent.extras?.getString(EXTRA_REF_NAME) }
     private val refType by lazy { intent.extras?.getInt(EXTRA_REF_TYPE) ?: NATIVE }

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/Extensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/Extensions.kt
@@ -1,0 +1,3 @@
+package com.absinthe.libchecker.utils
+
+fun <T> unsafeLazy(initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/detail/AppBundleBottomSheetView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/detail/AppBundleBottomSheetView.kt
@@ -8,10 +8,11 @@ import androidx.recyclerview.widget.RecyclerView
 import com.absinthe.libchecker.extensions.dp
 import com.absinthe.libchecker.recyclerview.VerticalSpacesItemDecoration
 import com.absinthe.libchecker.recyclerview.adapter.detail.AppBundleAdapter
+import com.absinthe.libchecker.utils.unsafeLazy
 
 class AppBundleBottomSheetView(context: Context) : LinearLayout(context) {
 
-    val adapter by lazy { AppBundleAdapter() }
+    val adapter by unsafeLazy { AppBundleAdapter() }
 
     init {
         layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/TimeNodeBottomSheetView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/TimeNodeBottomSheetView.kt
@@ -8,10 +8,11 @@ import androidx.recyclerview.widget.RecyclerView
 import com.absinthe.libchecker.extensions.dp
 import com.absinthe.libchecker.recyclerview.VerticalSpacesItemDecoration
 import com.absinthe.libchecker.recyclerview.adapter.snapshot.TimeNodeAdapter
+import com.absinthe.libchecker.utils.unsafeLazy
 
 class TimeNodeBottomSheetView(context: Context) : LinearLayout(context) {
 
-    val adapter by lazy { TimeNodeAdapter() }
+    val adapter by unsafeLazy { TimeNodeAdapter() }
 
     init {
         layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/statistics/ClassifyDialogView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/statistics/ClassifyDialogView.kt
@@ -14,12 +14,13 @@ import com.absinthe.libchecker.recyclerview.adapter.AppAdapter
 import com.absinthe.libchecker.ui.detail.AppDetailActivity
 import com.absinthe.libchecker.ui.detail.EXTRA_DETAIL_BEAN
 import com.absinthe.libchecker.ui.detail.EXTRA_PACKAGE_NAME
+import com.absinthe.libchecker.utils.unsafeLazy
 import me.zhanghai.android.fastscroll.FastScrollerBuilder
 
 @SuppressLint("ViewConstructor")
 class ClassifyDialogView(context: Context, val lifecycleScope: LifecycleCoroutineScope) : LinearLayout(context) {
 
-    val adapter by lazy { AppAdapter(lifecycleScope) }
+    val adapter by unsafeLazy { AppAdapter(lifecycleScope) }
 
     init {
         layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)


### PR DESCRIPTION
增加了一个扩展方法 `unsafeLazy`
```kotlin
fun <T> unsafeLazy(initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)
```
用以替换原有的部分 `lazy`，因为 kotlin 的 `lazy` 默认用的是双检锁方式，部分初始化双检索没啥意义，不存在并发问题

![image](https://user-images.githubusercontent.com/10363352/125173553-8d117980-e1f2-11eb-8ce8-6b2b947804cf.png)
