### PR TITLE
Add java.srcDirs("src/main/kotlin")

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,8 @@ android {
         freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-XXLanguage:+InlineClasses")
     }
 
+    sourceSets["main"].java.srcDirs("src/main/kotlin")
+
     packagingOptions.resources.excludes += setOf(
         "META-INF/**",
         "okhttp3/**",


### PR DESCRIPTION
对 #82 的补充提交，那个合并 sourceSet 之后会报找不到类的错误，我的工程是纯 kotlin 的，之前没报过这个问题，头一次遇到。
添加一下 `sourceSets["main"].java.srcDirs("src/main/kotlin")` 就可以了