### PR TITLE
Fix crash when show toast with application & Make LibCheckerApp's static context as application

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/LibCheckerApp.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/LibCheckerApp.kt
@@ -30,7 +30,7 @@ class LibCheckerApp : Application() {
             HiddenApiBypass.addHiddenApiExemptions("L")
         }
 
-        context = this
+        app = this
         if (!BuildConfig.DEBUG && GlobalValues.isAnonymousAnalyticsEnabled.value == true) {
             AppCenter.start(
                 this, Constants.APP_CENTER_SECRET,
@@ -59,6 +59,6 @@ class LibCheckerApp : Application() {
 
     companion object {
         @SuppressLint("StaticFieldLeak")
-        lateinit var context: Context
+        lateinit var app: Application
     }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/SystemServices.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/SystemServices.kt
@@ -1,8 +1,7 @@
 package com.absinthe.libchecker
 
 import android.content.pm.PackageManager
-import com.absinthe.libchecker.LibCheckerApp
 
 object SystemServices {
-    val packageManager: PackageManager by lazy { LibCheckerApp.context.packageManager }
+    val packageManager: PackageManager by lazy { LibCheckerApp.app.packageManager }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/app/Global.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/app/Global.kt
@@ -33,10 +33,10 @@ object Global {
             Timber.w(e)
         } else if (stack.contains("ClipboardService")) {
             Timber.w(e)
-            LibCheckerApp.context.showToast("Cannot access to ClipboardService")
+            LibCheckerApp.app.showToast("Cannot access to ClipboardService")
         } else if (stack.contains("de.robv.android.xposed")) {
             Timber.w(e)
-            LibCheckerApp.context.showToast("Encounter Xposed module crash")
+            LibCheckerApp.app.showToast("Encounter Xposed module crash")
         } else {
             throw e
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/constant/GlobalValues.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/constant/GlobalValues.kt
@@ -17,7 +17,7 @@ const val SP_NAME = "${BuildConfig.APPLICATION_ID}_preferences"
 
 object GlobalValues {
 
-    private val preferences: SharedPreferences = LibCheckerApp.context
+    private val preferences: SharedPreferences = LibCheckerApp.app
         .getSharedPreferences(SP_NAME, Context.MODE_PRIVATE)
 
     private fun getPreferences(): SharedPreferences {

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/SPUtils.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/SPUtils.kt
@@ -8,7 +8,7 @@ import com.absinthe.libchecker.constant.SP_NAME
 object SPUtils {
 
     private val sp by lazy {
-        LibCheckerApp.context.getSharedPreferences(SP_NAME, Context.MODE_PRIVATE)
+        LibCheckerApp.app.getSharedPreferences(SP_NAME, Context.MODE_PRIVATE)
     }
 
     fun putString(key: String, value: String) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/Toasty.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/Toasty.kt
@@ -62,6 +62,7 @@ object Toasty {
         if (LCAppUtils.atLeastR() && context !is Activity) {
             Toast(context).also {
                 it.duration = duration
+                it.setText(message)
                 toast = WeakReference(it)
             }.show()
         } else {

--- a/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
@@ -12,12 +12,12 @@ import androidx.lifecycle.viewModelScope
 import com.absinthe.libchecker.LibCheckerApp
 import com.absinthe.libchecker.SystemServices
 import com.absinthe.libchecker.annotation.*
+import com.absinthe.libchecker.bean.LibChip
 import com.absinthe.libchecker.bean.LibReference
 import com.absinthe.libchecker.bean.LibStringItem
 import com.absinthe.libchecker.bean.StatefulComponent
 import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.constant.GlobalValues
-import com.absinthe.libchecker.bean.LibChip
 import com.absinthe.libchecker.constant.OnceTag
 import com.absinthe.libchecker.constant.librarymap.IconResMap
 import com.absinthe.libchecker.database.AppItemRepository
@@ -212,7 +212,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
         dbItems.value?.let { value ->
             val isHarmony = HarmonyOsUtil.isHarmonyOs()
-            val bundleManager by lazy { ApplicationDelegate(LibCheckerApp.context).iBundleManager }
+            val bundleManager by lazy { ApplicationDelegate(LibCheckerApp.app).iBundleManager }
             var packageInfo: PackageInfo
             var versionCode: Long
             var lcItem: LCItem


### PR DESCRIPTION
- 修复 toast 缺少 text 抛出异常
- `LibCheckerApp` 的 context 写成 app 可能更方便一点 

![Snipaste_2021-07-11_23-44-35](https://user-images.githubusercontent.com/10363352/125202996-f8b61e00-e2a8-11eb-97b3-088327fc79a7.png)
