### PR TITLE
Replace bundle put with `bundleOf` extension function

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/integrations/monkeyking/MonkeyKingManager.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/integrations/monkeyking/MonkeyKingManager.kt
@@ -2,7 +2,8 @@ package com.absinthe.libchecker.integrations.monkeyking
 
 import android.content.Context
 import android.net.Uri
-import android.os.Bundle
+import androidx.core.net.toUri
+import androidx.core.os.bundleOf
 import com.absinthe.libchecker.annotation.*
 import com.absinthe.libchecker.utils.PackageUtils
 import com.absinthe.libchecker.utils.showToast
@@ -34,18 +35,25 @@ class MonkeyKingManager {
     fun addBlockedComponent(context: Context, packageName: String,
                             componentName: String, @LibType type: Int,
                             shouldBlock: Boolean) {
-        val fullComponentName = if (componentName.startsWith(".")) { packageName + componentName } else { componentName }
-        val shareCmpInfo = ShareCmpInfo(packageName, listOf( ShareCmpInfo.Component(
-            type = getType(type),
-            name = fullComponentName,
-            block = shouldBlock
-        ) ))
-        val bundle = Bundle().apply {
-            putString("cmp_list", Gson().toJson(shareCmpInfo))
+        val fullComponentName = if (componentName.startsWith(".")) {
+            packageName + componentName
+        } else {
+            componentName
         }
-        val uri = Uri.parse(URI_AUTHORIZATION)
+        val shareCmpInfo = ShareCmpInfo(
+            packageName, listOf(
+                ShareCmpInfo.Component(
+                    type = getType(type),
+                    name = fullComponentName,
+                    block = shouldBlock
+                )
+            )
+        )
+        val bundle = bundleOf(
+            "cmp_list" to Gson().toJson(shareCmpInfo)
+        )
         try {
-            context.contentResolver.call(uri, "blocks", packageName, bundle)
+            context.contentResolver.call(URI_AUTHORIZATION.toUri(), "blocks", packageName, bundle)
         } catch (e: Exception) {
             context.showToast(e.message.toString())
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
@@ -8,6 +8,7 @@ import android.view.MenuItem
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.activity.viewModels
+import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -184,11 +185,12 @@ class ComparisonActivity : BaseActivity() {
                     return@setOnItemClickListener
                 }
 
-                val intent = Intent(this@ComparisonActivity, SnapshotDetailActivity::class.java).apply {
-                    putExtras(Bundle().apply {
-                        putSerializable(EXTRA_ENTITY, getItem(position))
-                    })
-                }
+                val intent = Intent(this@ComparisonActivity, SnapshotDetailActivity::class.java)
+                    .putExtras(
+                        bundleOf(
+                            EXTRA_ENTITY to getItem(position)
+                        )
+                    )
 
                 startActivity(intent)
             }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
@@ -17,6 +17,7 @@ import android.view.ViewGroup
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -36,9 +37,9 @@ import com.absinthe.libchecker.ui.fragment.detail.*
 import com.absinthe.libchecker.ui.fragment.detail.impl.*
 import com.absinthe.libchecker.ui.main.EXTRA_REF_NAME
 import com.absinthe.libchecker.ui.main.EXTRA_REF_TYPE
-import com.absinthe.libchecker.utils.manifest.ManifestReader
 import com.absinthe.libchecker.utils.PackageUtils
 import com.absinthe.libchecker.utils.harmony.ApplicationDelegate
+import com.absinthe.libchecker.utils.manifest.ManifestReader
 import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.view.detail.CenterAlignImageSpan
 import com.absinthe.libchecker.viewmodel.DetailViewModel
@@ -124,9 +125,9 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                         load(appIconLoader.loadIcon(packageInfo.applicationInfo))
                         setOnClickListener {
                             AppInfoBottomSheetDialogFragment().apply {
-                                arguments = Bundle().apply {
-                                    putString(EXTRA_PACKAGE_NAME, pkgName)
-                                }
+                                arguments = bundleOf(
+                                    EXTRA_PACKAGE_NAME to pkgName
+                                )
                                 show(supportFragmentManager, tag)
                             }
                         }
@@ -233,9 +234,9 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                                 isVisible = it.isSplitApk
                                 setOnClickListener {
                                     AppBundleBottomSheetDialogFragment().apply {
-                                        arguments = Bundle().apply {
-                                            putString(EXTRA_PACKAGE_NAME, pkgName)
-                                        }
+                                        arguments = bundleOf(
+                                            EXTRA_PACKAGE_NAME to pkgName
+                                        )
                                         show(supportFragmentManager, tag)
                                     }
                                 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
@@ -9,6 +9,7 @@ import android.view.MenuItem
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.activity.viewModels
+import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.SimpleItemAnimator
 import coil.load
@@ -200,14 +201,21 @@ class SnapshotDetailActivity : BaseActivity() {
             lifecycleScope.launch(Dispatchers.IO) {
                 val lcItem = Repositories.lcRepository.getItem(entity.packageName) ?: return@launch
                 withContext(Dispatchers.Main) {
-                    startActivity(Intent(this@SnapshotDetailActivity, AppDetailActivity::class.java).apply {
-                        putExtras(Bundle().apply {
-                            putString(EXTRA_PACKAGE_NAME, entity.packageName)
-                            putString(EXTRA_REF_NAME, item.name)
-                            putInt(EXTRA_REF_TYPE, item.itemType)
-                            putParcelable(EXTRA_DETAIL_BEAN, DetailExtraBean(lcItem.isSplitApk, lcItem.isKotlinUsed, lcItem.variant))
-                        })
-                    })
+                    startActivity(
+                        Intent(this@SnapshotDetailActivity, AppDetailActivity::class.java)
+                            .putExtras(
+                                bundleOf(
+                                    EXTRA_PACKAGE_NAME to entity.packageName,
+                                    EXTRA_REF_NAME to item.name,
+                                    EXTRA_REF_TYPE to item.itemType,
+                                    EXTRA_DETAIL_BEAN to DetailExtraBean(
+                                        lcItem.isSplitApk,
+                                        lcItem.isKotlinUsed,
+                                        lcItem.variant
+                                    )
+                                )
+                            )
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/applist/AppListFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/applist/AppListFragment.kt
@@ -4,12 +4,12 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Color
-import android.os.Bundle
 import android.view.*
 import android.widget.TextView
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.PopupMenu
 import androidx.appcompat.widget.SearchView
+import androidx.core.os.bundleOf
 import androidx.core.view.get
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -68,14 +68,18 @@ class AppListFragment : BaseListControllerFragment<FragmentAppListBinding>(R.lay
                 if (AntiShakeUtils.isInvalidClick(view)) {
                     return@setOnItemClickListener
                 }
-
-                val intent = Intent(requireActivity(), AppDetailActivity::class.java).apply {
-                    putExtras(Bundle().apply {
-                        val item = mAdapter.getItem(position)
-                        putString(EXTRA_PACKAGE_NAME, item.packageName)
-                        putParcelable(EXTRA_DETAIL_BEAN, DetailExtraBean(item.isSplitApk, item.isKotlinUsed, item.variant))
-                    })
-                }
+                val item = mAdapter.getItem(position)
+                val intent = Intent(requireActivity(), AppDetailActivity::class.java)
+                    .putExtras(
+                        bundleOf(
+                            EXTRA_PACKAGE_NAME to item.packageName,
+                            EXTRA_DETAIL_BEAN to DetailExtraBean(
+                                item.isSplitApk,
+                                item.isKotlinUsed,
+                                item.variant
+                            )
+                        )
+                    )
                 startActivity(intent)
             }
             setDiffCallback(AppListDiffUtil())

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/LibDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/LibDetailDialogFragment.kt
@@ -1,7 +1,6 @@
 package com.absinthe.libchecker.ui.fragment.detail
 
 import android.content.DialogInterface
-import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.FragmentManager
@@ -14,6 +13,7 @@ import com.absinthe.libchecker.annotation.NATIVE
 import com.absinthe.libchecker.constant.librarymap.IconResMap
 import com.absinthe.libchecker.ui.fragment.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.putArguments
 import com.absinthe.libchecker.view.app.BottomSheetHeaderView
 import com.absinthe.libchecker.view.detail.LibDetailBottomSheetView
 import com.absinthe.libchecker.view.detail.VF_CONTENT
@@ -117,14 +117,11 @@ class LibDetailDialogFragment : BaseBottomSheetViewDialogFragment<LibDetailBotto
             @LibType type: Int,
             regexName: String? = null
         ): LibDetailDialogFragment {
-            return LibDetailDialogFragment()
-                .apply {
-                    arguments = Bundle().apply {
-                        putString(EXTRA_LIB_NAME, libName)
-                        putInt(EXTRA_LIB_TYPE, type)
-                        putString(EXTRA_REGEX_NAME, regexName)
-                    }
-                }
+            return LibDetailDialogFragment().putArguments(
+                EXTRA_LIB_NAME to libName,
+                EXTRA_LIB_TYPE to type,
+                EXTRA_REGEX_NAME to regexName
+            )
         }
 
         var isShowing = false

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/AbilityAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/AbilityAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -17,6 +16,7 @@ import com.absinthe.libchecker.ui.fragment.detail.LibDetailDialogFragment
 import com.absinthe.libchecker.ui.fragment.detail.LocatedCount
 import com.absinthe.libchecker.ui.fragment.detail.MODE_SORT_BY_LIB
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.putArguments
 import com.absinthe.libchecker.utils.showToast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -108,12 +108,9 @@ class AbilityAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>(
 
     companion object {
         fun newInstance(@LibType type: Int): AbilityAnalysisFragment {
-            return AbilityAnalysisFragment()
-                .apply {
-                    arguments = Bundle().apply {
-                        putInt(EXTRA_TYPE, type)
-                    }
-                }
+            return AbilityAnalysisFragment().putArguments(
+                EXTRA_TYPE to type
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/ComponentsAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/ComponentsAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.os.Bundle
 import android.view.View
 import android.widget.ArrayAdapter
 import androidx.appcompat.app.AlertDialog
@@ -10,9 +9,9 @@ import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.ACTIVITY
 import com.absinthe.libchecker.annotation.LibType
 import com.absinthe.libchecker.bean.DISABLED
+import com.absinthe.libchecker.bean.LibChip
 import com.absinthe.libchecker.bean.LibStringItem
 import com.absinthe.libchecker.bean.LibStringItemChip
-import com.absinthe.libchecker.bean.LibChip
 import com.absinthe.libchecker.constant.librarymap.IconResMap
 import com.absinthe.libchecker.database.entity.RuleEntity
 import com.absinthe.libchecker.databinding.FragmentLibComponentBinding
@@ -26,6 +25,7 @@ import com.absinthe.libchecker.ui.fragment.detail.LibDetailDialogFragment
 import com.absinthe.libchecker.ui.fragment.detail.LocatedCount
 import com.absinthe.libchecker.ui.fragment.detail.MODE_SORT_BY_LIB
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.putArguments
 import com.absinthe.libchecker.utils.showToast
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import kotlinx.coroutines.Dispatchers
@@ -182,12 +182,9 @@ class ComponentsAnalysisFragment : BaseDetailFragment<FragmentLibComponentBindin
 
     companion object {
         fun newInstance(@LibType type: Int): ComponentsAnalysisFragment {
-            return ComponentsAnalysisFragment()
-                .apply {
-                    arguments = Bundle().apply {
-                        putInt(EXTRA_TYPE, type)
-                    }
-                }
+            return ComponentsAnalysisFragment().putArguments(
+                EXTRA_TYPE to type
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/DexAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/DexAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -15,6 +14,7 @@ import com.absinthe.libchecker.ui.fragment.EXTRA_TYPE
 import com.absinthe.libchecker.ui.fragment.detail.LibDetailDialogFragment
 import com.absinthe.libchecker.ui.fragment.detail.LocatedCount
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.putArguments
 import com.absinthe.libchecker.utils.showToast
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import rikka.core.util.ClipboardUtils
@@ -83,13 +83,10 @@ class DexAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>(R.la
 
     companion object {
         fun newInstance(packageName: String, @LibType type: Int): DexAnalysisFragment {
-            return DexAnalysisFragment()
-                .apply {
-                    arguments = Bundle().apply {
-                        putString(EXTRA_PACKAGE_NAME, packageName)
-                        putInt(EXTRA_TYPE, type)
-                    }
-                }
+            return DexAnalysisFragment().putArguments(
+                EXTRA_PACKAGE_NAME to packageName,
+                EXTRA_TYPE to type
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/NativeAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/NativeAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Observer
 import com.absinthe.libchecker.R
@@ -14,6 +13,7 @@ import com.absinthe.libchecker.ui.fragment.EXTRA_TYPE
 import com.absinthe.libchecker.ui.fragment.detail.LibDetailDialogFragment
 import com.absinthe.libchecker.ui.fragment.detail.LocatedCount
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.putArguments
 import com.absinthe.libchecker.utils.showToast
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import rikka.core.util.ClipboardUtils
@@ -76,13 +76,10 @@ class NativeAnalysisFragment : BaseDetailFragment<FragmentLibNativeBinding>(R.la
 
     companion object {
         fun newInstance(packageName: String, @LibType type: Int): NativeAnalysisFragment {
-            return NativeAnalysisFragment()
-                .apply {
-                    arguments = Bundle().apply {
-                        putString(EXTRA_PACKAGE_NAME, packageName)
-                        putInt(EXTRA_TYPE, type)
-                    }
-                }
+            return NativeAnalysisFragment().putArguments(
+                EXTRA_PACKAGE_NAME to packageName,
+                EXTRA_TYPE to type
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/StaticAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/StaticAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Observer
 import com.absinthe.libchecker.R
@@ -14,6 +13,7 @@ import com.absinthe.libchecker.ui.fragment.EXTRA_TYPE
 import com.absinthe.libchecker.ui.fragment.detail.LibDetailDialogFragment
 import com.absinthe.libchecker.ui.fragment.detail.LocatedCount
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.putArguments
 import com.absinthe.libchecker.utils.showToast
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import rikka.core.util.ClipboardUtils
@@ -76,13 +76,10 @@ class StaticAnalysisFragment : BaseDetailFragment<FragmentLibNativeBinding>(R.la
 
     companion object {
         fun newInstance(packageName: String, @LibType type: Int): StaticAnalysisFragment {
-            return StaticAnalysisFragment()
-                .apply {
-                    arguments = Bundle().apply {
-                        putString(EXTRA_PACKAGE_NAME, packageName)
-                        putInt(EXTRA_TYPE, type)
-                    }
-                }
+            return StaticAnalysisFragment().putArguments(
+                EXTRA_PACKAGE_NAME to packageName,
+                EXTRA_TYPE to type
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
@@ -5,11 +5,11 @@ import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
 import android.content.res.Configuration
-import android.os.Bundle
 import android.os.IBinder
 import android.view.*
 import android.widget.FrameLayout
 import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -162,11 +162,12 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(R.l
                     return@setOnItemClickListener
                 }
 
-                val intent = Intent(requireActivity(), SnapshotDetailActivity::class.java).apply {
-                    putExtras(Bundle().apply {
-                        putSerializable(EXTRA_ENTITY, getItem(position))
-                    })
-                }
+                val intent = Intent(requireActivity(), SnapshotDetailActivity::class.java)
+                    .putExtras(
+                        bundleOf(
+                            EXTRA_ENTITY to getItem(position)
+                        )
+                    )
                 startActivity(intent)
             }
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/TimeNodeBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/TimeNodeBottomSheetDialogFragment.kt
@@ -1,17 +1,18 @@
 package com.absinthe.libchecker.ui.fragment.snapshot
 
-import android.os.Bundle
 import android.view.ViewGroup
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.database.entity.TimeStampItem
 import com.absinthe.libchecker.extensions.dp
 import com.absinthe.libchecker.ui.fragment.BaseBottomSheetViewDialogFragment
+import com.absinthe.libchecker.utils.putArguments
 import com.absinthe.libchecker.view.app.BottomSheetHeaderView
 import com.absinthe.libchecker.view.snapshot.TimeNodeBottomSheetView
 
 const val EXTRA_TOP_APPS = "EXTRA_TOP_APPS"
 
-class TimeNodeBottomSheetDialogFragment : BaseBottomSheetViewDialogFragment<TimeNodeBottomSheetView>() {
+class TimeNodeBottomSheetDialogFragment :
+    BaseBottomSheetViewDialogFragment<TimeNodeBottomSheetView>() {
 
     private lateinit var headerView: BottomSheetHeaderView
 
@@ -33,9 +34,11 @@ class TimeNodeBottomSheetDialogFragment : BaseBottomSheetViewDialogFragment<Time
         }
         root.adapter.setHeaderView(headerView)
         customTitle?.let { headerView.title.text = it }
-        itemClickAction?.let { root.adapter.setOnItemClickListener { _, _, position ->
-            it(position)
-        } }
+        itemClickAction?.let {
+            root.adapter.setOnItemClickListener { _, _, position ->
+                it(position)
+            }
+        }
 
         arguments?.getParcelableArrayList<TimeStampItem>(EXTRA_TOP_APPS)?.let { topApps ->
             root.adapter.setList(topApps)
@@ -52,11 +55,9 @@ class TimeNodeBottomSheetDialogFragment : BaseBottomSheetViewDialogFragment<Time
 
     companion object {
         fun newInstance(topApps: ArrayList<TimeStampItem>): TimeNodeBottomSheetDialogFragment {
-            return TimeNodeBottomSheetDialogFragment().apply {
-                arguments = Bundle().apply {
-                    putParcelableArrayList(EXTRA_TOP_APPS, topApps)
-                }
-            }
+            return TimeNodeBottomSheetDialogFragment().putArguments(
+                EXTRA_TOP_APPS to topApps
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
@@ -4,12 +4,12 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Build
-import android.os.Bundle
 import android.view.HapticFeedbackConstants
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.constant.Constants.ARMV5
@@ -383,9 +383,9 @@ class ChartFragment : BaseFragment<FragmentPieChartBinding>(R.layout.fragment_pi
         }
 
         mDialog = ClassifyBottomSheetDialogFragment().apply {
-            arguments = Bundle().apply {
-                putString(EXTRA_TITLE, dialogTitle)
-            }
+            arguments = bundleOf(
+                EXTRA_TITLE to dialogTitle
+            )
             setOnDismissListener(object : ClassifyBottomSheetDialogFragment.OnDismissListener {
                 override fun onDismiss() {
                     mDialog = null

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import android.view.ViewGroup
 import androidx.activity.viewModels
+import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
@@ -119,7 +120,7 @@ class LibReferenceActivity : BaseActivity() {
             lottie.apply {
                 imageAssetsFolder = "/"
 
-                val assetName = when(GlobalValues.season) {
+                val assetName = when (GlobalValues.season) {
                     SPRING -> "lib_reference_spring.json"
                     SUMMER -> "lib_reference_summer.json"
                     AUTUMN -> "lib_reference_autumn.json"
@@ -140,16 +141,20 @@ class LibReferenceActivity : BaseActivity() {
             if (AntiShakeUtils.isInvalidClick(view)) {
                 return@setOnItemClickListener
             }
-
-            val intent = Intent(this, AppDetailActivity::class.java).apply {
-                putExtras(Bundle().apply {
-                    val item = adapter.getItem(position)
-                    putString(EXTRA_PACKAGE_NAME, item.packageName)
-                    putString(EXTRA_REF_NAME, refName)
-                    putInt(EXTRA_REF_TYPE, refType)
-                    putParcelable(EXTRA_DETAIL_BEAN, DetailExtraBean(item.isSplitApk, item.isKotlinUsed, item.variant))
-                })
-            }
+            val item = adapter.getItem(position)
+            val intent = Intent(this, AppDetailActivity::class.java)
+                .putExtras(
+                    bundleOf(
+                        EXTRA_PACKAGE_NAME to item.packageName,
+                        EXTRA_REF_NAME to refName,
+                        EXTRA_REF_TYPE to refType,
+                        EXTRA_DETAIL_BEAN to DetailExtraBean(
+                            item.isSplitApk,
+                            item.isKotlinUsed,
+                            item.variant
+                        )
+                    )
+                )
             startActivity(intent)
         }
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/Extensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/Extensions.kt
@@ -1,3 +1,18 @@
 package com.absinthe.libchecker.utils
 
+import android.os.Bundle
+import androidx.annotation.MainThread
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+
 fun <T> unsafeLazy(initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)
+
+@MainThread
+fun <T : Fragment> T.putArguments(bundle: Bundle): T {
+    arguments = bundle
+    return this
+}
+
+@MainThread
+fun <T : Fragment> T.putArguments(vararg pairs: Pair<String, Any?>): T =
+    putArguments(bundleOf(*pairs))

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/statistics/ClassifyDialogView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/statistics/ClassifyDialogView.kt
@@ -3,8 +3,8 @@ package com.absinthe.libchecker.view.statistics
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
 import android.widget.LinearLayout
+import androidx.core.os.bundleOf
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -26,12 +26,18 @@ class ClassifyDialogView(context: Context, val lifecycleScope: LifecycleCoroutin
         layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
         addPaddingTop(16.dp)
         adapter.setOnItemClickListener { _, _, position ->
+            val item = adapter.getItem(position)
             val intent = Intent(context, AppDetailActivity::class.java).apply {
-                putExtras(Bundle().apply {
-                    val item = adapter.getItem(position)
-                    putString(EXTRA_PACKAGE_NAME, item.packageName)
-                    putParcelable(EXTRA_DETAIL_BEAN, DetailExtraBean(item.isSplitApk, item.isKotlinUsed, item.variant))
-                })
+                putExtras(
+                    bundleOf(
+                        EXTRA_PACKAGE_NAME to item.packageName,
+                        EXTRA_DETAIL_BEAN to DetailExtraBean(
+                            item.isSplitApk,
+                            item.isKotlinUsed,
+                            item.variant
+                        )
+                    )
+                )
             }
             context.startActivity(intent)
         }


### PR DESCRIPTION
- core-ktx 里面带有一个 `bundleOf` 的扩展方法，用以替代 `Bundle().put` 更方便，更优雅
- 增加 `Fragment.putArguments()` 扩展方法方便于构造 Fragment
```kotlin
@MainThread
fun <T : Fragment> T.putArguments(vararg pairs: Pair<String, Any?>): T = putArguments(bundleOf(*pairs))
```
- `Intent().putExtra` 方法的返回值是 intent，使用时不需要外面包裹 `apply`，多此一举