### PR TITLE
Remove redundant coroutines scoops switch

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/database/LCDao.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/database/LCDao.kt
@@ -12,7 +12,7 @@ interface LCDao {
     fun getItems(): LiveData<List<LCItem>>
 
     @Query("SELECT * from item_table WHERE packageName LIKE :packageName")
-    fun getItem(packageName: String): LCItem?
+    suspend fun getItem(packageName: String): LCItem?
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(item: LCItem)

--- a/app/src/main/kotlin/com/absinthe/libchecker/database/LCRepository.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/database/LCRepository.kt
@@ -9,7 +9,7 @@ class LCRepository(private val lcDao: LCDao) {
     val allDatabaseItems: LiveData<List<LCItem>> = lcDao.getItems()
     val allSnapshotItems: LiveData<List<SnapshotItem>> = lcDao.getSnapshotsLiveData(GlobalValues.snapshotTimestamp)
 
-    fun getItem(packageName: String): LCItem? {
+    suspend fun getItem(packageName: String): LCItem? {
         return lcDao.getItem(packageName)
     }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
@@ -19,9 +19,7 @@ import com.absinthe.libchecker.view.snapshot.SnapshotDetailComponentView
 import com.chad.library.adapter.base.entity.node.BaseNode
 import com.chad.library.adapter.base.provider.BaseNodeProvider
 import com.chad.library.adapter.base.viewholder.BaseViewHolder
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 const val SNAPSHOT_COMPONENT_PROVIDER = 3
 
@@ -31,7 +29,9 @@ class SnapshotComponentProvider(val lifecycleScope: LifecycleCoroutineScope) : B
     override val layoutId: Int = 0
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder {
-        return BaseViewHolder(SnapshotDetailComponentView(ContextThemeWrapper(context, R.style.AppListMaterialCard)))
+        return BaseViewHolder(
+            SnapshotDetailComponentView(ContextThemeWrapper(context, R.style.AppListMaterialCard))
+        )
     }
 
     override fun convert(helper: BaseViewHolder, item: BaseNode) {
@@ -58,25 +58,25 @@ class SnapshotComponentProvider(val lifecycleScope: LifecycleCoroutineScope) : B
                 }
             )
 
-            helper.itemView.backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
+            helper.itemView.backgroundTintList =
+                ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
 
-            lifecycleScope.launch(Dispatchers.IO) {
+            lifecycleScope.launch {
                 val rule = LCAppUtils.getRuleWithRegex(snapshotItem.name, snapshotItem.itemType)
 
-                withContext(Dispatchers.Main) {
-                    setChip(rule, colorRes)
-                    if (rule != null) {
-                        setChipOnClickListener {
-                            val name = item.item.name
-                            val regexName = LCAppUtils.findRuleRegex(name, item.item.itemType)?.regexName
-                            LibDetailDialogFragment.newInstance(name, item.item.itemType, regexName)
-                                .apply {
-                                    show((this@SnapshotComponentProvider.context as BaseActivity).supportFragmentManager, tag)
-                                }
-                        }
-                    } else {
-                        setChipOnClickListener(null)
+                setChip(rule, colorRes)
+                if (rule != null) {
+                    setChipOnClickListener {
+                        val name = item.item.name
+                        val regexName =
+                            LCAppUtils.findRuleRegex(name, item.item.itemType)?.regexName
+                        LibDetailDialogFragment.newInstance(name, item.item.itemType, regexName)
+                            .apply {
+                                show((context as BaseActivity).supportFragmentManager, tag)
+                            }
                     }
+                } else {
+                    setChipOnClickListener(null)
                 }
             }
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
@@ -19,9 +19,7 @@ import com.absinthe.libchecker.view.snapshot.SnapshotDetailNativeView
 import com.chad.library.adapter.base.entity.node.BaseNode
 import com.chad.library.adapter.base.provider.BaseNodeProvider
 import com.chad.library.adapter.base.viewholder.BaseViewHolder
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 const val SNAPSHOT_NATIVE_PROVIDER = 2
 
@@ -31,7 +29,9 @@ class SnapshotNativeProvider(val lifecycleScope: LifecycleCoroutineScope) : Base
     override val layoutId: Int = 0
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder {
-        return BaseViewHolder(SnapshotDetailNativeView(ContextThemeWrapper(context, R.style.AppListMaterialCard)))
+        return BaseViewHolder(
+            SnapshotDetailNativeView(ContextThemeWrapper(context, R.style.AppListMaterialCard))
+        )
     }
 
     override fun convert(helper: BaseViewHolder, item: BaseNode) {
@@ -57,25 +57,25 @@ class SnapshotNativeProvider(val lifecycleScope: LifecycleCoroutineScope) : Base
                 }
             )
 
-            helper.itemView.backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
+            helper.itemView.backgroundTintList =
+                ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
 
-            lifecycleScope.launch(Dispatchers.IO) {
+            lifecycleScope.launch {
                 val rule = LCAppUtils.getRuleWithRegex(snapshotItem.name, NATIVE)
 
-                withContext(Dispatchers.Main) {
-                    setChip(rule, colorRes)
-                    if (rule != null) {
-                        setChipOnClickListener {
-                            val name = item.item.name
-                            val regexName = LCAppUtils.findRuleRegex(name, item.item.itemType)?.regexName
-                            LibDetailDialogFragment.newInstance(name, item.item.itemType, regexName)
-                                .apply {
-                                    show((this@SnapshotNativeProvider.context as BaseActivity).supportFragmentManager, tag)
-                                }
-                        }
-                    } else {
-                        setChipOnClickListener(null)
+                setChip(rule, colorRes)
+                if (rule != null) {
+                    setChipOnClickListener {
+                        val name = item.item.name
+                        val regexName =
+                            LCAppUtils.findRuleRegex(name, item.item.itemType)?.regexName
+                        LibDetailDialogFragment.newInstance(name, item.item.itemType, regexName)
+                            .apply {
+                                show((context as BaseActivity).supportFragmentManager, tag)
+                            }
                     }
+                } else {
+                    setChipOnClickListener(null)
                 }
             }
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
@@ -28,9 +28,7 @@ import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.view.snapshot.SnapshotEmptyView
 import com.absinthe.libchecker.viewmodel.SnapshotViewModel
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import rikka.widget.borderview.BorderView
 
 const val VF_LOADING = 0
@@ -77,50 +75,49 @@ class ComparisonActivity : BaseActivity() {
         dashboardBinding.apply {
             infoLeft.horizontalGravity = Gravity.START
             infoLeft.setOnClickListener {
-                lifecycleScope.launch(Dispatchers.IO) {
+                lifecycleScope.launch {
                     val timeStampList = viewModel.repository.getTimeStamps()
-                    withContext(Dispatchers.Main) {
-                        val dialog = TimeNodeBottomSheetDialogFragment.newInstance(ArrayList(timeStampList)).apply {
+                    val dialog = TimeNodeBottomSheetDialogFragment
+                        .newInstance(ArrayList(timeStampList))
+                        .apply {
                             setOnItemClickListener { position ->
                                 val item = timeStampList[position]
                                 leftTimeStamp = item.timestamp
-                                infoLeft.tvSnapshotTimestampText.text = viewModel.getFormatDateString(leftTimeStamp)
-                                lifecycleScope.launch(Dispatchers.IO) {
-                                    val count = viewModel.repository.getSnapshots(leftTimeStamp).size
-
-                                    withContext(Dispatchers.Main) {
-                                        infoLeft.tvSnapshotAppsCountText.text = count.toString()
-                                    }
+                                infoLeft.tvSnapshotTimestampText.text =
+                                    viewModel.getFormatDateString(leftTimeStamp)
+                                lifecycleScope.launch {
+                                    val count =
+                                        viewModel.repository.getSnapshots(leftTimeStamp).size
+                                    infoLeft.tvSnapshotAppsCountText.text = count.toString()
                                 }
                                 dismiss()
                             }
                         }
-                        dialog.show(supportFragmentManager, dialog.tag)
-                    }
+                    dialog.show(supportFragmentManager, dialog.tag)
                 }
             }
             infoRight.horizontalGravity = Gravity.END
             infoRight.setOnClickListener {
-                lifecycleScope.launch(Dispatchers.IO) {
+                lifecycleScope.launch {
                     val timeStampList = viewModel.repository.getTimeStamps()
-                    withContext(Dispatchers.Main) {
-                        val dialog = TimeNodeBottomSheetDialogFragment.newInstance(ArrayList(timeStampList)).apply {
+                    val dialog = TimeNodeBottomSheetDialogFragment
+                        .newInstance(ArrayList(timeStampList))
+                        .apply {
                             setOnItemClickListener { position ->
                                 val item = timeStampList[position]
                                 rightTimeStamp = item.timestamp
-                                infoRight.tvSnapshotTimestampText.text = viewModel.getFormatDateString(rightTimeStamp)
-                                lifecycleScope.launch(Dispatchers.IO) {
-                                    val count = viewModel.repository.getSnapshots(rightTimeStamp).size
+                                infoRight.tvSnapshotTimestampText.text =
+                                    viewModel.getFormatDateString(rightTimeStamp)
+                                lifecycleScope.launch {
+                                    val count =
+                                        viewModel.repository.getSnapshots(rightTimeStamp).size
 
-                                    withContext(Dispatchers.Main) {
-                                        infoRight.tvSnapshotAppsCountText.text = count.toString()
-                                    }
+                                    infoRight.tvSnapshotAppsCountText.text = count.toString()
                                 }
                                 dismiss()
                             }
                         }
-                        dialog.show(supportFragmentManager, dialog.tag)
-                    }
+                    dialog.show(supportFragmentManager, dialog.tag)
                 }
             }
         }
@@ -129,7 +126,11 @@ class ComparisonActivity : BaseActivity() {
             extendedFab.apply {
                 post {
                     (layoutParams as ViewGroup.MarginLayoutParams).setMargins(
-                        0, 0, 16.dp, paddingBottom + (window.decorView.rootWindowInsets?.systemWindowInsetBottom ?: 0)
+                        0,
+                        0,
+                        16.dp,
+                        paddingBottom + (window.decorView.rootWindowInsets?.systemWindowInsetBottom
+                            ?: 0)
                     )
                 }
                 setOnClickListener {
@@ -139,7 +140,10 @@ class ComparisonActivity : BaseActivity() {
                     if (leftTimeStamp == rightTimeStamp || leftTimeStamp == 0L || rightTimeStamp == 0L) {
                         return@setOnClickListener
                     }
-                    viewModel.compareDiff(leftTimeStamp.coerceAtMost(rightTimeStamp), leftTimeStamp.coerceAtLeast(rightTimeStamp))
+                    viewModel.compareDiff(
+                        leftTimeStamp.coerceAtMost(rightTimeStamp),
+                        leftTimeStamp.coerceAtLeast(rightTimeStamp)
+                    )
                     flip(VF_LOADING)
                 }
                 setOnLongClickListener {
@@ -173,7 +177,10 @@ class ComparisonActivity : BaseActivity() {
         adapter.apply {
             headerWithEmptyEnable = true
             val emptyView = SnapshotEmptyView(this@ComparisonActivity).apply {
-                layoutParams = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT).also {
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.WRAP_CONTENT
+                ).also {
                     it.gravity = Gravity.CENTER_HORIZONTAL
                 }
                 addPaddingTop(96.dp)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
@@ -63,15 +63,13 @@ class TrackActivity : BaseActivity(), SearchView.OnQueryTextListener {
             setDiffCallback(TrackListDiff())
 
             fun doSaveItemState(pos: Int, state: Boolean) {
-                lifecycleScope.launch(Dispatchers.IO) {
+                lifecycleScope.launch {
                     if (state) {
                         repository.insert(TrackItem(data[pos].packageName))
                     } else {
                         repository.delete(TrackItem(data[pos].packageName))
                     }
-                    withContext(Dispatchers.Main) {
-                        list.find { it.packageName == data[pos].packageName }?.switchState = state
-                    }
+                    list.find { it.packageName == data[pos].packageName }?.switchState = state
                 }
                 AppItemRepository.trackItemsChanged = true
             }
@@ -91,9 +89,8 @@ class TrackActivity : BaseActivity(), SearchView.OnQueryTextListener {
         }
 
         lifecycleScope.launch(Dispatchers.IO) {
-            val appList = AppItemRepository.getApplicationInfoItems()
             val trackedList = repository.getTrackItems()
-            list.addAll(appList
+            list += AppItemRepository.getApplicationInfoItems()
                 .asSequence()
                 .map {
                     TrackListItem(
@@ -104,14 +101,16 @@ class TrackActivity : BaseActivity(), SearchView.OnQueryTextListener {
                 }
                 .sortedByDescending { it.switchState }
                 .toList()
-            )
 
             withContext(Dispatchers.Main) {
                 adapter.setList(list)
                 menu?.findItem(R.id.search)?.isVisible = true
                 isListReady = true
                 adapter.setEmptyView(EmptyListView(this@TrackActivity).apply {
-                    layoutParams = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT).also {
+                    layoutParams = FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT
+                    ).also {
                         it.gravity = Gravity.CENTER
                     }
                 })

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
@@ -30,16 +30,14 @@ import com.absinthe.libchecker.ui.fragment.detail.impl.DexAnalysisFragment
 import com.absinthe.libchecker.ui.fragment.detail.impl.NativeAnalysisFragment
 import com.absinthe.libchecker.ui.fragment.detail.impl.StaticAnalysisFragment
 import com.absinthe.libchecker.utils.FileUtils
-import com.absinthe.libchecker.utils.manifest.ManifestReader
 import com.absinthe.libchecker.utils.PackageUtils
+import com.absinthe.libchecker.utils.manifest.ManifestReader
 import com.absinthe.libchecker.utils.showToast
 import com.absinthe.libchecker.view.detail.CenterAlignImageSpan
 import com.absinthe.libchecker.viewmodel.DetailViewModel
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import me.zhanghai.android.appiconloader.AppIconLoader
 import timber.log.Timber
 import java.io.File
@@ -117,7 +115,11 @@ class ApkDetailActivity : BaseActivity(), IDetailContainer {
                 }
                 binding.apply {
                     try {
-                        val appIconLoader = AppIconLoader(resources.getDimensionPixelSize(R.dimen.lib_detail_icon_size), false, this@ApkDetailActivity)
+                        val appIconLoader = AppIconLoader(
+                            resources.getDimensionPixelSize(R.dimen.lib_detail_icon_size),
+                            false,
+                            this@ApkDetailActivity
+                        )
                         ivAppIcon.load(appIconLoader.loadIcon(it.applicationInfo))
                         tvAppName.apply {
                             text = it.applicationInfo.loadLabel(packageManager)
@@ -134,17 +136,28 @@ class ApkDetailActivity : BaseActivity(), IDetailContainer {
 
                         val extraInfo = SpannableStringBuilder()
                         val file = File(packageInfo.applicationInfo.sourceDir)
-                        val demands = ManifestReader.getManifestProperties(file, listOf(
-                            PackageUtils.use32bitAbiString,
-                            PackageUtils.multiArchString,
-                            PackageUtils.overlayString
-                        ).toTypedArray())
+                        val demands = ManifestReader.getManifestProperties(
+                            file, listOf(
+                                PackageUtils.use32bitAbiString,
+                                PackageUtils.multiArchString,
+                                PackageUtils.overlayString
+                            ).toTypedArray()
+                        )
                         val overlay = demands[PackageUtils.overlayString] as? Boolean ?: false
-                        val abiSet = PackageUtils.getAbiSet(file, packageInfo.applicationInfo,  isApk = true, overlay = overlay, ignoreArch = true)
+                        val abiSet = PackageUtils.getAbiSet(
+                            file,
+                            packageInfo.applicationInfo,
+                            isApk = true,
+                            overlay = overlay,
+                            ignoreArch = true
+                        )
                         val abi = PackageUtils.getAbi(abiSet, demands)
                         viewModel.is32bit = PackageUtils.is32bit(abi)
 
-                        if (abiSet.isNotEmpty() && !abiSet.contains(Constants.OVERLAY) && !abiSet.contains(Constants.ERROR)) {
+                        if (abiSet.isNotEmpty() && !abiSet.contains(Constants.OVERLAY) && !abiSet.contains(
+                                Constants.ERROR
+                            )
+                        ) {
                             val spanStringBuilder = SpannableStringBuilder()
                             var spanString: SpannableString
                             var firstLoop = true
@@ -154,9 +167,25 @@ class ApkDetailActivity : BaseActivity(), IDetailContainer {
                                 if (firstLoop) {
                                     firstLoop = false
                                 }
-                                spanString = SpannableString("  ${PackageUtils.getAbiString(this@ApkDetailActivity, eachAbi, false)}")
-                                ContextCompat.getDrawable(this@ApkDetailActivity, PackageUtils.getAbiBadgeResource(eachAbi))?.mutate()?.let { drawable ->
-                                    drawable.setBounds(0, 0, drawable.intrinsicWidth, drawable.intrinsicHeight)
+                                spanString = SpannableString(
+                                    "  ${
+                                        PackageUtils.getAbiString(
+                                            this@ApkDetailActivity,
+                                            eachAbi,
+                                            false
+                                        )
+                                    }"
+                                )
+                                ContextCompat.getDrawable(
+                                    this@ApkDetailActivity,
+                                    PackageUtils.getAbiBadgeResource(eachAbi)
+                                )?.mutate()?.let { drawable ->
+                                    drawable.setBounds(
+                                        0,
+                                        0,
+                                        drawable.intrinsicWidth,
+                                        drawable.intrinsicHeight
+                                    )
                                     if (eachAbi != abi % Constants.MULTI_ARCH) {
                                         drawable.alpha = 128
                                     } else {
@@ -166,7 +195,12 @@ class ApkDetailActivity : BaseActivity(), IDetailContainer {
                                     spanString.setSpan(span, 0, 1, ImageSpan.ALIGN_BOTTOM)
                                 }
                                 if (eachAbi != abi % Constants.MULTI_ARCH) {
-                                    spanString.setSpan(StrikethroughSpan(), 2, spanString.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+                                    spanString.setSpan(
+                                        StrikethroughSpan(),
+                                        2,
+                                        spanString.length,
+                                        Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+                                    )
                                 }
                                 spanStringBuilder.append(spanString)
                                 if (itemCount < abiSet.size) {
@@ -179,7 +213,7 @@ class ApkDetailActivity : BaseActivity(), IDetailContainer {
                             extraInfo.append(spanStringBuilder).appendLine()
                         }
 
-                        val advanced = when(abi) {
+                        val advanced = when (abi) {
                             Constants.ERROR -> getString(R.string.cannot_read)
                             Constants.OVERLAY -> Constants.OVERLAY_STRING
                             else -> ""
@@ -208,10 +242,12 @@ class ApkDetailActivity : BaseActivity(), IDetailContainer {
                     ibSort.setOnClickListener {
                         lifecycleScope.launch {
                             detailFragmentManager.sortAll()
-                            withContext(Dispatchers.Main) {
-                                viewModel.sortMode = if (viewModel.sortMode == MODE_SORT_BY_LIB) { MODE_SORT_BY_SIZE } else { MODE_SORT_BY_LIB }
-                                detailFragmentManager.changeSortMode(viewModel.sortMode)
+                            viewModel.sortMode = if (viewModel.sortMode == MODE_SORT_BY_LIB) {
+                                MODE_SORT_BY_SIZE
+                            } else {
+                                MODE_SORT_BY_LIB
                             }
+                            detailFragmentManager.changeSortMode(viewModel.sortMode)
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
@@ -45,9 +45,7 @@ import com.absinthe.libchecker.view.detail.CenterAlignImageSpan
 import com.absinthe.libchecker.viewmodel.DetailViewModel
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import me.zhanghai.android.appiconloader.AppIconLoader
 import ohos.bundle.IBundleManager
 import timber.log.Timber
@@ -121,7 +119,11 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                         }
                     }
                     ivAppIcon.apply {
-                        val appIconLoader = AppIconLoader(resources.getDimensionPixelSize(R.dimen.lib_detail_icon_size), false, this@AppDetailActivity)
+                        val appIconLoader = AppIconLoader(
+                            resources.getDimensionPixelSize(R.dimen.lib_detail_icon_size),
+                            false,
+                            this@AppDetailActivity
+                        )
                         load(appIconLoader.loadIcon(packageInfo.applicationInfo))
                         setOnClickListener {
                             AppInfoBottomSheetDialogFragment().apply {
@@ -147,17 +149,28 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
 
                     val extraInfo = SpannableStringBuilder()
                     val file = File(packageInfo.applicationInfo.sourceDir)
-                    val demands = ManifestReader.getManifestProperties(file, listOf(
-                        PackageUtils.use32bitAbiString,
-                        PackageUtils.multiArchString,
-                        PackageUtils.overlayString
-                    ).toTypedArray())
+                    val demands = ManifestReader.getManifestProperties(
+                        file, listOf(
+                            PackageUtils.use32bitAbiString,
+                            PackageUtils.multiArchString,
+                            PackageUtils.overlayString
+                        ).toTypedArray()
+                    )
                     val overlay = demands[PackageUtils.overlayString] as? Boolean ?: false
-                    val abiSet = PackageUtils.getAbiSet(file, packageInfo.applicationInfo, isApk = false, overlay = overlay, ignoreArch = true)
+                    val abiSet = PackageUtils.getAbiSet(
+                        file,
+                        packageInfo.applicationInfo,
+                        isApk = false,
+                        overlay = overlay,
+                        ignoreArch = true
+                    )
                     val abi = PackageUtils.getAbi(abiSet, demands)
                     viewModel.is32bit = PackageUtils.is32bit(abi)
 
-                    if (abiSet.isNotEmpty() && !abiSet.contains(Constants.OVERLAY) && !abiSet.contains(Constants.ERROR)) {
+                    if (abiSet.isNotEmpty() && !abiSet.contains(Constants.OVERLAY) && !abiSet.contains(
+                            Constants.ERROR
+                        )
+                    ) {
                         val spanStringBuilder = SpannableStringBuilder()
                         var spanString: SpannableString
                         var firstLoop = true
@@ -167,9 +180,25 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                             if (firstLoop) {
                                 firstLoop = false
                             }
-                            spanString = SpannableString("  ${PackageUtils.getAbiString(this@AppDetailActivity, it, false)}")
-                            ContextCompat.getDrawable(this@AppDetailActivity, PackageUtils.getAbiBadgeResource(it))?.mutate()?.let { drawable ->
-                                drawable.setBounds(0, 0, drawable.intrinsicWidth, drawable.intrinsicHeight)
+                            spanString = SpannableString(
+                                "  ${
+                                    PackageUtils.getAbiString(
+                                        this@AppDetailActivity,
+                                        it,
+                                        false
+                                    )
+                                }"
+                            )
+                            ContextCompat.getDrawable(
+                                this@AppDetailActivity,
+                                PackageUtils.getAbiBadgeResource(it)
+                            )?.mutate()?.let { drawable ->
+                                drawable.setBounds(
+                                    0,
+                                    0,
+                                    drawable.intrinsicWidth,
+                                    drawable.intrinsicHeight
+                                )
                                 if (it != abi % Constants.MULTI_ARCH) {
                                     drawable.alpha = 128
                                 } else {
@@ -179,7 +208,12 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                                 spanString.setSpan(span, 0, 1, ImageSpan.ALIGN_BOTTOM)
                             }
                             if (it != abi % Constants.MULTI_ARCH) {
-                                spanString.setSpan(StrikethroughSpan(), 2, spanString.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+                                spanString.setSpan(
+                                    StrikethroughSpan(),
+                                    2,
+                                    spanString.length,
+                                    Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+                                )
                             }
                             spanStringBuilder.append(spanString)
                             if (itemCount < abiSet.size) {
@@ -192,7 +226,7 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                         extraInfo.append(spanStringBuilder).appendLine()
                     }
 
-                    val advanced = when(abi) {
+                    val advanced = when (abi) {
                         Constants.ERROR -> getString(R.string.cannot_read)
                         Constants.OVERLAY -> Constants.OVERLAY_STRING
                         else -> ""
@@ -215,7 +249,10 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                         } else {
                             if (extraBean != null && extraBean!!.variant == Constants.VARIANT_HAP) {
                                 bundleManager?.let {
-                                    val hapBundle = it.getBundleInfo(packageName, IBundleManager.GET_BUNDLE_DEFAULT)
+                                    val hapBundle = it.getBundleInfo(
+                                        packageName,
+                                        IBundleManager.GET_BUNDLE_DEFAULT
+                                    )
                                     append("targetVersion ${hapBundle.targetVersion}")
                                     append(", ").append("minSdkVersion ${hapBundle.minSdkVersion}")
                                     if (!hapBundle.jointUserId.isNullOrEmpty()) {
@@ -271,14 +308,12 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                 ibSort.setOnClickListener {
                     lifecycleScope.launch {
                         detailFragmentManager.sortAll()
-                        withContext(Dispatchers.Main) {
-                            viewModel.sortMode = if (viewModel.sortMode == MODE_SORT_BY_LIB) {
-                                MODE_SORT_BY_SIZE
-                            } else {
-                                MODE_SORT_BY_LIB
-                            }
-                            detailFragmentManager.changeSortMode(viewModel.sortMode)
+                        viewModel.sortMode = if (viewModel.sortMode == MODE_SORT_BY_LIB) {
+                            MODE_SORT_BY_SIZE
+                        } else {
+                            MODE_SORT_BY_LIB
                         }
+                        detailFragmentManager.changeSortMode(viewModel.sortMode)
                     }
                 }
 
@@ -296,7 +331,12 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                 )
             } else {
                 mutableListOf(
-                    NATIVE, AbilityType.PAGE, AbilityType.SERVICE, AbilityType.WEB, AbilityType.DATA, DEX
+                    NATIVE,
+                    AbilityType.PAGE,
+                    AbilityType.SERVICE,
+                    AbilityType.WEB,
+                    AbilityType.DATA,
+                    DEX
                 )
             }
             val tabTitles = if (!isHarmonyMode) {
@@ -319,7 +359,9 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                 )
             }
             try {
-                if (PackageUtils.getStaticLibs(PackageUtils.getPackageInfo(packageName)).isNotEmpty()) {
+                if (PackageUtils.getStaticLibs(PackageUtils.getPackageInfo(packageName))
+                        .isNotEmpty()
+                ) {
                     types.add(1, STATIC)
                     tabTitles.add(1, getText(R.string.ref_category_static))
                 }
@@ -368,9 +410,10 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
                 })
             }
 
-            val mediator = TabLayoutMediator(binding.tabLayout, binding.viewpager) { tab, position ->
-                tab.text = tabTitles[position]
-            }
+            val mediator =
+                TabLayoutMediator(binding.tabLayout, binding.viewpager) { tab, position ->
+                    tab.text = tabTitles[position]
+                }
             mediator.attach()
 
             viewModel.itemsCountLiveData.observe(this, {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
@@ -44,9 +44,7 @@ import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import com.chad.library.adapter.base.entity.node.BaseNode
 import com.microsoft.appcenter.analytics.Analytics
 import com.microsoft.appcenter.analytics.EventProperties
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import me.zhanghai.android.appiconloader.AppIconLoader
 
 const val EXTRA_ENTITY = "EXTRA_ENTITY"
@@ -103,17 +101,30 @@ class SnapshotDetailActivity : BaseActivity() {
             val isNewOrDeleted = entity.deleted || entity.newInstalled
 
             ivAppIcon.apply {
-                val appIconLoader = AppIconLoader(resources.getDimensionPixelSize(R.dimen.lib_detail_icon_size), false, this@SnapshotDetailActivity)
+                val appIconLoader = AppIconLoader(
+                    resources.getDimensionPixelSize(R.dimen.lib_detail_icon_size),
+                    false,
+                    this@SnapshotDetailActivity
+                )
                 val icon = try {
-                    appIconLoader.loadIcon(PackageUtils.getPackageInfo(entity.packageName, PackageManager.GET_META_DATA).applicationInfo)
+                    appIconLoader.loadIcon(
+                        PackageUtils.getPackageInfo(
+                            entity.packageName,
+                            PackageManager.GET_META_DATA
+                        ).applicationInfo
+                    )
                 } catch (e: PackageManager.NameNotFoundException) {
                     null
                 }
                 load(icon)
                 setOnClickListener {
-                    startActivity(Intent(this@SnapshotDetailActivity, AppDetailActivity::class.java).apply {
-                        putExtra(EXTRA_PACKAGE_NAME, entity.packageName)
-                    })
+                    startActivity(
+                        Intent(
+                            this@SnapshotDetailActivity,
+                            AppDetailActivity::class.java
+                        ).apply {
+                            putExtra(EXTRA_PACKAGE_NAME, entity.packageName)
+                        })
                 }
             }
             tvAppName.text = getDiffString(entity.labelDiff, isNewOrDeleted)
@@ -133,37 +144,55 @@ class SnapshotDetailActivity : BaseActivity() {
             getNodeList(details.filter { it.itemType == NATIVE }).apply {
                 if (isNotEmpty()) {
                     titleList.add(SnapshotTitleNode(this, NATIVE))
-                    Analytics.trackEvent(Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT, EventProperties().set("Native", this.size.toLong()))
+                    Analytics.trackEvent(
+                        Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT,
+                        EventProperties().set("Native", this.size.toLong())
+                    )
                 }
             }
             getNodeList(details.filter { it.itemType == SERVICE }).apply {
                 if (isNotEmpty()) {
                     titleList.add(SnapshotTitleNode(this, SERVICE))
-                    Analytics.trackEvent(Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT, EventProperties().set("Service", this.size.toLong()))
+                    Analytics.trackEvent(
+                        Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT,
+                        EventProperties().set("Service", this.size.toLong())
+                    )
                 }
             }
             getNodeList(details.filter { it.itemType == ACTIVITY }).apply {
                 if (isNotEmpty()) {
                     titleList.add(SnapshotTitleNode(this, ACTIVITY))
-                    Analytics.trackEvent(Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT, EventProperties().set("Activity", this.size.toLong()))
+                    Analytics.trackEvent(
+                        Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT,
+                        EventProperties().set("Activity", this.size.toLong())
+                    )
                 }
             }
             getNodeList(details.filter { it.itemType == RECEIVER }).apply {
                 if (isNotEmpty()) {
                     titleList.add(SnapshotTitleNode(this, RECEIVER))
-                    Analytics.trackEvent(Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT, EventProperties().set("Receiver", this.size.toLong()))
+                    Analytics.trackEvent(
+                        Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT,
+                        EventProperties().set("Receiver", this.size.toLong())
+                    )
                 }
             }
             getNodeList(details.filter { it.itemType == PROVIDER }).apply {
                 if (isNotEmpty()) {
                     titleList.add(SnapshotTitleNode(this, PROVIDER))
-                    Analytics.trackEvent(Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT, EventProperties().set("Provider", this.size.toLong()))
+                    Analytics.trackEvent(
+                        Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT,
+                        EventProperties().set("Provider", this.size.toLong())
+                    )
                 }
             }
             getNodeList(details.filter { it.itemType == PERMISSION }).apply {
                 if (isNotEmpty()) {
                     titleList.add(SnapshotTitleNode(this, PERMISSION))
-                    Analytics.trackEvent(Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT, EventProperties().set("Permission", this.size.toLong()))
+                    Analytics.trackEvent(
+                        Constants.Event.SNAPSHOT_DETAIL_COMPONENT_COUNT,
+                        EventProperties().set("Permission", this.size.toLong())
+                    )
                 }
             }
 
@@ -177,7 +206,10 @@ class SnapshotDetailActivity : BaseActivity() {
                 entity.newInstalled -> SnapshotDetailNewInstallView(this)
                 entity.deleted -> SnapshotDetailDeletedView(this)
                 else -> SnapshotEmptyView(this).apply {
-                    layoutParams = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT).also {
+                    layoutParams = FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.WRAP_CONTENT
+                    ).also {
                         it.gravity = Gravity.CENTER_HORIZONTAL
                     }
                     addPaddingTop(96.dp)
@@ -198,25 +230,23 @@ class SnapshotDetailActivity : BaseActivity() {
                 return@setOnItemClickListener
             }
 
-            lifecycleScope.launch(Dispatchers.IO) {
+            lifecycleScope.launch {
                 val lcItem = Repositories.lcRepository.getItem(entity.packageName) ?: return@launch
-                withContext(Dispatchers.Main) {
-                    startActivity(
-                        Intent(this@SnapshotDetailActivity, AppDetailActivity::class.java)
-                            .putExtras(
-                                bundleOf(
-                                    EXTRA_PACKAGE_NAME to entity.packageName,
-                                    EXTRA_REF_NAME to item.name,
-                                    EXTRA_REF_TYPE to item.itemType,
-                                    EXTRA_DETAIL_BEAN to DetailExtraBean(
-                                        lcItem.isSplitApk,
-                                        lcItem.isKotlinUsed,
-                                        lcItem.variant
-                                    )
+                startActivity(
+                    Intent(this@SnapshotDetailActivity, AppDetailActivity::class.java)
+                        .putExtras(
+                            bundleOf(
+                                EXTRA_PACKAGE_NAME to entity.packageName,
+                                EXTRA_REF_NAME to item.name,
+                                EXTRA_REF_TYPE to item.itemType,
+                                EXTRA_DETAIL_BEAN to DetailExtraBean(
+                                    lcItem.isSplitApk,
+                                    lcItem.isKotlinUsed,
+                                    lcItem.variant
                                 )
                             )
-                    )
-                }
+                        )
+                )
             }
         }
     }
@@ -241,7 +271,12 @@ class SnapshotDetailActivity : BaseActivity() {
         format: String = "%s"
     ): String {
         return if (diff.old != diff.new && !isNewOrDeleted) {
-            "${String.format(format, diff.old.toString())} $ARROW ${String.format(format, diff.new.toString())}"
+            "${String.format(format, diff.old.toString())} $ARROW ${
+                String.format(
+                    format,
+                    diff.new.toString()
+                )
+            }"
         } else {
             String.format(format, diff.old.toString())
         }
@@ -254,7 +289,13 @@ class SnapshotDetailActivity : BaseActivity() {
         format: String = "%s"
     ): String {
         return if ((diff1.old != diff1.new || diff2.old != diff2.new) && !isNewOrDeleted) {
-            "${String.format(format, diff1.old.toString(), diff2.old.toString())} $ARROW ${String.format(format, diff1.new.toString(), diff2.new.toString())}"
+            "${
+                String.format(
+                    format,
+                    diff1.old.toString(),
+                    diff2.old.toString()
+                )
+            } $ARROW ${String.format(format, diff1.new.toString(), diff2.new.toString())}"
         } else {
             String.format(format, diff1.old.toString(), diff2.old.toString())
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/LibDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/LibDetailDialogFragment.kt
@@ -20,9 +20,7 @@ import com.absinthe.libchecker.view.detail.VF_CONTENT
 import com.absinthe.libchecker.view.detail.VF_LOADING
 import com.absinthe.libchecker.view.detail.VF_NOT_FOUND
 import com.absinthe.libchecker.viewmodel.DetailViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 const val EXTRA_LIB_NAME = "EXTRA_LIB_NAME"
 const val EXTRA_LIB_TYPE = "EXTRA_LIB_TYPE"
@@ -36,19 +34,18 @@ class LibDetailDialogFragment : BaseBottomSheetViewDialogFragment<LibDetailBotto
     private val viewModel by activityViewModels<DetailViewModel>()
     private var isStickyEventReceived = false
 
-    override fun initRootView(): LibDetailBottomSheetView = LibDetailBottomSheetView(requireContext())
+    override fun initRootView(): LibDetailBottomSheetView =
+        LibDetailBottomSheetView(requireContext())
 
     override fun init() {
         root.apply {
             viewFlipper.displayedChild = VF_LOADING
             title.text = libName
-            lifecycleScope.launch(Dispatchers.IO) {
+            lifecycleScope.launch {
                 val iconIndex = LCAppUtils.getRuleWithRegex(libName, type)?.iconIndex ?: -1
-                withContext(Dispatchers.Main) {
-                    icon.load(IconResMap.getIconRes(iconIndex)) {
-                        crossfade(true)
-                        placeholder(R.drawable.ic_logo)
-                    }
+                icon.load(IconResMap.getIconRes(iconIndex)) {
+                    crossfade(true)
+                    placeholder(R.drawable.ic_logo)
                 }
             }
         }
@@ -73,7 +70,10 @@ class LibDetailDialogFragment : BaseBottomSheetViewDialogFragment<LibDetailBotto
                         relativeLink.text.apply {
                             isClickable = true
                             movementMethod = LinkMovementMethod.getInstance()
-                            text = HtmlCompat.fromHtml("<a href='${it.relativeUrl}'> ${it.relativeUrl} </a>", HtmlCompat.FROM_HTML_MODE_LEGACY)
+                            text = HtmlCompat.fromHtml(
+                                "<a href='${it.relativeUrl}'> ${it.relativeUrl} </a>",
+                                HtmlCompat.FROM_HTML_MODE_LEGACY
+                            )
                         }
                     }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/Sortable.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/Sortable.kt
@@ -1,5 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail
 
-interface Sortable {
+fun interface Sortable {
     suspend fun sort()
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/AbilityAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/AbilityAnalysisFragment.kt
@@ -24,9 +24,12 @@ import kotlinx.coroutines.withContext
 import rikka.core.util.ClipboardUtils
 
 
-class AbilityAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>(R.layout.fragment_lib_component) {
+class AbilityAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>(
+    R.layout.fragment_lib_component
+) {
 
-    override fun initBinding(view: View): FragmentLibComponentBinding = FragmentLibComponentBinding.bind(view)
+    override fun initBinding(view: View): FragmentLibComponentBinding =
+        FragmentLibComponentBinding.bind(view)
 
     override fun getRecyclerView() = binding.list
 
@@ -46,10 +49,15 @@ class AbilityAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>(
                         val list = mutableListOf<LibStringItemChip>()
 
                         for (item in componentList) {
-                            if (item.enabled) {
-                                list.add(LibStringItemChip(LibStringItem(item.componentName), null))
+                            list += if (item.enabled) {
+                                LibStringItemChip(LibStringItem(item.componentName), null)
                             } else {
-                                list.add(LibStringItemChip(LibStringItem(name = item.componentName, source = DISABLED), null))
+                                LibStringItemChip(
+                                    LibStringItem(
+                                        name = item.componentName,
+                                        source = DISABLED
+                                    ), null
+                                )
                             }
                         }
 
@@ -62,8 +70,7 @@ class AbilityAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>(
                         withContext(Dispatchers.Main) {
                             binding.list.addItemDecoration(
                                 DividerItemDecoration(
-                                    requireContext(),
-                                    DividerItemDecoration.VERTICAL
+                                    requireContext(), DividerItemDecoration.VERTICAL
                                 )
                             )
                             adapter.setDiffNewData(list, navigateToComponentTask)
@@ -71,7 +78,8 @@ class AbilityAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>(
                     }
                 }
                 if (!isListReady) {
-                    viewModel.itemsCountLiveData.value = LocatedCount(locate = type, count = componentList.size)
+                    viewModel.itemsCountLiveData.value =
+                        LocatedCount(locate = type, count = componentList.size)
                     viewModel.itemsCountList[type] = componentList.size
                     isListReady = true
                 }
@@ -82,7 +90,8 @@ class AbilityAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>(
             val name = adapter.getItem(position).item.name
             val regexName = LCAppUtils.findRuleRegex(name, adapter.type)?.regexName
 
-            LibDetailDialogFragment.newInstance(name, adapter.type, regexName).show(childFragmentManager, tag)
+            LibDetailDialogFragment.newInstance(name, adapter.type, regexName)
+                .show(childFragmentManager, tag)
         }
 
         adapter.apply {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/ComponentsAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/ComponentsAnalysisFragment.kt
@@ -66,12 +66,21 @@ class ComponentsAnalysisFragment : BaseDetailFragment<FragmentLibComponentBindin
                             rule = LCAppUtils.getRuleWithRegex(item.componentName, adapter.type)
                             chip = null
                             if (rule != null) {
-                                chip = LibChip(iconRes = IconResMap.getIconRes(rule.iconIndex), name = rule.label, regexName = rule.regexName)
+                                chip = LibChip(
+                                    iconRes = IconResMap.getIconRes(rule.iconIndex),
+                                    name = rule.label,
+                                    regexName = rule.regexName
+                                )
                             }
-                            if (item.enabled) {
-                                list.add(LibStringItemChip(LibStringItem(item.componentName), chip))
+                            list += if (item.enabled) {
+                                LibStringItemChip(LibStringItem(item.componentName), chip)
                             } else {
-                                list.add(LibStringItemChip(LibStringItem(name = item.componentName, source = DISABLED), chip))
+                                LibStringItemChip(
+                                    LibStringItem(
+                                        name = item.componentName,
+                                        source = DISABLED
+                                    ), chip
+                                )
                             }
                         }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
@@ -46,13 +46,14 @@ import com.microsoft.appcenter.analytics.EventProperties
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import rikka.widget.borderview.BorderView
 
 const val VF_LOADING = 0
 const val VF_LIST = 1
 
-class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(R.layout.fragment_snapshot) {
+class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(
+    R.layout.fragment_snapshot
+) {
 
     private val viewModel by activityViewModels<SnapshotViewModel>()
     private val adapter by unsafeLazy { SnapshotAdapter(lifecycleScope) }
@@ -97,12 +98,15 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(R.l
         }
     }
 
-    override fun initBinding(view: View): FragmentSnapshotBinding = FragmentSnapshotBinding.bind(view)
+    override fun initBinding(view: View): FragmentSnapshotBinding =
+        FragmentSnapshotBinding.bind(view)
 
     override fun init() {
         setHasOptionsMenu(true)
 
-        val dashboard = SnapshotDashboardView(ContextThemeWrapper(requireContext(), R.style.AlbumMaterialCard)).apply {
+        val dashboard = SnapshotDashboardView(
+            ContextThemeWrapper(requireContext(), R.style.AlbumMaterialCard)
+        ).apply {
             layoutParams = ViewGroup.MarginLayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
@@ -117,10 +121,11 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(R.l
         dashboard.container.apply {
 
             fun changeTimeNode() {
-                lifecycleScope.launch(Dispatchers.IO) {
+                lifecycleScope.launch {
                     val timeStampList = viewModel.repository.getTimeStamps()
-                    withContext(Dispatchers.Main) {
-                        val dialog = TimeNodeBottomSheetDialogFragment.newInstance(ArrayList(timeStampList)).apply {
+                    val dialog = TimeNodeBottomSheetDialogFragment
+                        .newInstance(ArrayList(timeStampList))
+                        .apply {
                             setOnItemClickListener { position ->
                                 val item = timeStampList[position]
                                 GlobalValues.snapshotTimestamp = item.timestamp
@@ -130,8 +135,7 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(R.l
                                 dismiss()
                             }
                         }
-                        dialog.show(requireActivity().supportFragmentManager, dialog.tag)
-                    }
+                    dialog.show(requireActivity().supportFragmentManager, dialog.tag)
                 }
             }
 
@@ -144,7 +148,10 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(R.l
         }
 
         val emptyView = SnapshotEmptyView(requireContext()).apply {
-            layoutParams = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT).also {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT
+            ).also {
                 it.gravity = Gravity.CENTER_HORIZONTAL
             }
             addPaddingTop(96.dp)
@@ -203,7 +210,8 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(R.l
                 if (it != 0L) {
                     dashboard.container.tvSnapshotTimestampText.text = getFormatDateString(it)
                 } else {
-                    dashboard.container.tvSnapshotTimestampText.text = getString(R.string.snapshot_none)
+                    dashboard.container.tvSnapshotTimestampText.text =
+                        getString(R.string.snapshot_none)
                     snapshotDiffItems.value = emptyList()
                     flip(VF_LIST)
                 }
@@ -220,7 +228,8 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(R.l
             })
             snapshotDiffItems.observe(
                 viewLifecycleOwner, { list ->
-                    adapter.setDiffNewData(list.sortedByDescending { it.updateTime }.toMutableList()) {
+                    adapter.setDiffNewData(list.sortedByDescending { it.updateTime }
+                        .toMutableList()) {
                         if (!binding.list.canScrollVertically(1)) {
                             if (!hasAddedListBottomPadding) {
                                 binding.list.addPaddingBottom(100.dp)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/LibReferenceFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/LibReferenceFragment.kt
@@ -30,9 +30,7 @@ import com.absinthe.libchecker.view.statistics.LibReferenceItemView
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import com.microsoft.appcenter.analytics.Analytics
 import com.microsoft.appcenter.analytics.EventProperties
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import rikka.widget.borderview.BorderView
 
@@ -135,9 +133,7 @@ class LibReferenceFragment : BaseListControllerFragment<FragmentLibReferenceBind
 
         lifecycleScope.launch {
             if (adapter.data.isEmpty() && AppItemRepository.getApplicationInfoItems().isNotEmpty()) {
-                withContext(Dispatchers.Main) {
-                    computeRef()
-                }
+                computeRef()
             }
         }
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
@@ -24,9 +24,7 @@ import com.absinthe.libchecker.utils.LCAppUtils
 import com.absinthe.libchecker.utils.unsafeLazy
 import com.absinthe.libchecker.viewmodel.LibReferenceViewModel
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import rikka.widget.borderview.BorderView
 
@@ -55,11 +53,9 @@ class LibReferenceActivity : BaseActivity() {
                 viewModel.setData(name, refType)
             })
 
-            lifecycleScope.launch(Dispatchers.IO) {
+            lifecycleScope.launch {
                 LCAppUtils.getRuleWithRegex(name, refType)?.let {
-                    withContext(Dispatchers.Main) {
-                        binding.toolbar.title = it.label
-                    }
+                    binding.toolbar.title = it.label
                 }
             }
         } ?: finish()

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
@@ -41,10 +41,30 @@ class AlbumActivity : BaseActivity() {
         (binding.root as ViewGroup).bringChildToFront(binding.appbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        val itemComparison = generateAlbumItemView(R.drawable.ic_compare, R.color.material_red_300, R.string.album_item_comparison_title, R.string.album_item_comparison_subtitle)
-        val itemManagement = generateAlbumItemView(R.drawable.ic_manage, R.color.material_blue_300, R.string.album_item_management_title, R.string.album_item_management_subtitle)
-        val itemBackupRestore = generateAlbumItemView(R.drawable.ic_backup, R.color.material_green_300, R.string.album_item_backup_restore_title, R.string.album_item_backup_restore_subtitle)
-        val itemTrack = generateAlbumItemView(R.drawable.ic_track, R.color.material_orange_300, R.string.album_item_track_title, R.string.album_item_track_subtitle)
+        val itemComparison = generateAlbumItemView(
+            R.drawable.ic_compare,
+            R.color.material_red_300,
+            R.string.album_item_comparison_title,
+            R.string.album_item_comparison_subtitle
+        )
+        val itemManagement = generateAlbumItemView(
+            R.drawable.ic_manage,
+            R.color.material_blue_300,
+            R.string.album_item_management_title,
+            R.string.album_item_management_subtitle
+        )
+        val itemBackupRestore = generateAlbumItemView(
+            R.drawable.ic_backup,
+            R.color.material_green_300,
+            R.string.album_item_backup_restore_title,
+            R.string.album_item_backup_restore_subtitle
+        )
+        val itemTrack = generateAlbumItemView(
+            R.drawable.ic_track,
+            R.color.material_orange_300,
+            R.string.album_item_track_title,
+            R.string.album_item_track_subtitle
+        )
         binding.llContainer.addView(itemComparison)
         binding.llContainer.addView(itemManagement)
         binding.llContainer.addView(itemBackupRestore)
@@ -54,11 +74,11 @@ class AlbumActivity : BaseActivity() {
             startActivity(Intent(this, ComparisonActivity::class.java))
         }
         itemManagement.setOnClickListener {
-            lifecycleScope.launch(Dispatchers.IO) {
+            lifecycleScope.launch {
                 val timeStampList = viewModel.repository.getTimeStamps().toMutableList()
-                withContext(Dispatchers.Main) {
-                    val dialog = TimeNodeBottomSheetDialogFragment.newInstance(ArrayList(timeStampList)).apply {
-                        setTitle(this@AlbumActivity.getString(R.string.dialog_title_select_to_delete))
+                val dialog = TimeNodeBottomSheetDialogFragment
+                    .newInstance(ArrayList(timeStampList)).apply {
+                        setTitle(getString(R.string.dialog_title_select_to_delete))
                         setOnItemClickListener { position ->
                             val item = timeStampList[position]
                             lifecycleScope.launch(Dispatchers.IO) {
@@ -84,8 +104,7 @@ class AlbumActivity : BaseActivity() {
                             }
                         }
                     }
-                    dialog.show(supportFragmentManager, dialog.tag)
-                }
+                dialog.show(supportFragmentManager, dialog.tag)
             }
         }
         itemBackupRestore.setOnClickListener {
@@ -103,9 +122,18 @@ class AlbumActivity : BaseActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    private fun generateAlbumItemView(iconRes: Int, iconBackgroundColorRes: Int, titleRes: Int, subtitleRes: Int): AlbumItemView = AlbumItemView(ContextThemeWrapper(this, R.style.AlbumMaterialCard)).apply {
-        layoutParams = ViewGroup.MarginLayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).also {
-            val marginHorizontal = context.getDimensionPixelSize(R.dimen.album_item_margin_horizontal)
+    private fun generateAlbumItemView(
+        iconRes: Int,
+        iconBackgroundColorRes: Int,
+        titleRes: Int,
+        subtitleRes: Int
+    ): AlbumItemView = AlbumItemView(ContextThemeWrapper(this, R.style.AlbumMaterialCard)).apply {
+        layoutParams = ViewGroup.MarginLayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ).also {
+            val marginHorizontal =
+                context.getDimensionPixelSize(R.dimen.album_item_margin_horizontal)
             val marginVertical = context.getDimensionPixelSize(R.dimen.album_item_margin_vertical)
             it.setMargins(marginHorizontal, marginVertical, marginHorizontal, marginVertical)
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
@@ -17,9 +17,7 @@ import com.absinthe.libchecker.ui.album.TrackActivity
 import com.absinthe.libchecker.ui.fragment.snapshot.TimeNodeBottomSheetDialogFragment
 import com.absinthe.libchecker.view.snapshot.AlbumItemView
 import com.absinthe.libchecker.viewmodel.SnapshotViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class AlbumActivity : BaseActivity() {
 
@@ -81,15 +79,12 @@ class AlbumActivity : BaseActivity() {
                         setTitle(getString(R.string.dialog_title_select_to_delete))
                         setOnItemClickListener { position ->
                             val item = timeStampList[position]
-                            lifecycleScope.launch(Dispatchers.IO) {
-                                val progressDialog: ProgressDialog
-                                withContext(Dispatchers.Main) {
-                                    progressDialog = ProgressDialog(this@AlbumActivity).apply {
-                                        setMessage(getString(R.string.album_dialog_delete_snapshot_message))
-                                        setCancelable(false)
-                                    }
-                                    progressDialog.show()
+                            lifecycleScope.launch {
+                                val progressDialog = ProgressDialog(this@AlbumActivity).apply {
+                                    setMessage(getString(R.string.album_dialog_delete_snapshot_message))
+                                    setCancelable(false)
                                 }
+                                progressDialog.show()
                                 viewModel.repository.deleteSnapshotsAndTimeStamp(item.timestamp)
                                 timeStampList.removeAt(position)
                                 GlobalValues.snapshotTimestamp = if (timeStampList.isEmpty()) {
@@ -97,10 +92,8 @@ class AlbumActivity : BaseActivity() {
                                 } else {
                                     timeStampList[0].timestamp
                                 }
-                                withContext(Dispatchers.Main) {
-                                    root.adapter.remove(item)
-                                    progressDialog.dismiss()
-                                }
+                                root.adapter.remove(item)
+                                progressDialog.dismiss()
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
@@ -106,9 +106,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         val timeRecorder = TimeRecorder()
         timeRecorder.start()
 
-        withContext(Dispatchers.Main) {
-            appListStatusLiveData.value = STATUS_START_INIT
-        }
+        appListStatusLiveData.postValue(STATUS_START_INIT)
         Repositories.lcRepository.deleteAllItems()
         initProgressLiveData.postValue(0)
 
@@ -175,15 +173,11 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
         insert(lcItems)
         lcItems.clear()
-        withContext(Dispatchers.Main) {
-            appListStatusLiveData.value = STATUS_INIT_END
-        }
+        appListStatusLiveData.postValue(STATUS_INIT_END)
 
         timeRecorder.end()
         Timber.d("initItems: END, $timeRecorder")
-        withContext(Dispatchers.Main) {
-            appListStatusLiveData.value = STATUS_NOT_START
-        }
+        appListStatusLiveData.postValue(STATUS_NOT_START)
     }
 
     fun requestChange(needRefresh: Boolean = false) = viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
@@ -195,9 +195,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         var appList: MutableList<ApplicationInfo>? = AppItemRepository.getApplicationInfoItems().toMutableList()
 
         timeRecorder.start()
-        withContext(Dispatchers.Main) {
-            appListStatusLiveData.value = STATUS_START_REQUEST_CHANGE
-        }
+        appListStatusLiveData.postValue(STATUS_START_REQUEST_CHANGE)
 
         if (appList.isNullOrEmpty() || needRefresh) {
             appList = getAppsList().toMutableList()
@@ -293,14 +291,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             GlobalValues.shouldRequestChange.postValue(true)
         }
 
-        withContext(Dispatchers.Main) {
-            appListStatusLiveData.value = STATUS_START_REQUEST_CHANGE_END
-        }
+        appListStatusLiveData.postValue(STATUS_START_REQUEST_CHANGE_END)
         timeRecorder.end()
         Timber.d("Request change: END, $timeRecorder")
-        withContext(Dispatchers.Main) {
-            appListStatusLiveData.value = STATUS_NOT_START
-        }
+        appListStatusLiveData.postValue(STATUS_NOT_START)
 
         if (!Once.beenDone(Once.THIS_APP_VERSION, OnceTag.HAS_COLLECT_LIB)) {
             delay(10000)

--- a/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
@@ -106,7 +106,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         val timeRecorder = TimeRecorder()
         timeRecorder.start()
 
-        appListStatusLiveData.postValue(STATUS_START_INIT)
+        withContext(Dispatchers.Main) {
+            appListStatusLiveData.value = STATUS_START_INIT
+        }
         Repositories.lcRepository.deleteAllItems()
         initProgressLiveData.postValue(0)
 
@@ -173,11 +175,15 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
         insert(lcItems)
         lcItems.clear()
-        appListStatusLiveData.postValue(STATUS_INIT_END)
+        withContext(Dispatchers.Main) {
+            appListStatusLiveData.value = STATUS_INIT_END
+        }
 
         timeRecorder.end()
         Timber.d("initItems: END, $timeRecorder")
-        appListStatusLiveData.postValue(STATUS_NOT_START)
+        withContext(Dispatchers.Main) {
+            appListStatusLiveData.value = STATUS_NOT_START
+        }
     }
 
     fun requestChange(needRefresh: Boolean = false) = viewModelScope.launch(Dispatchers.IO) {
@@ -192,10 +198,13 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private suspend fun requestChangeImpl(packageManager: PackageManager, needRefresh: Boolean = false) {
         Timber.d("Request change: START")
         val timeRecorder = TimeRecorder()
-        var appList: MutableList<ApplicationInfo>? = AppItemRepository.getApplicationInfoItems().toMutableList()
+        var appList: MutableList<ApplicationInfo>? =
+            AppItemRepository.getApplicationInfoItems().toMutableList()
 
         timeRecorder.start()
-        appListStatusLiveData.postValue(STATUS_START_REQUEST_CHANGE)
+        withContext(Dispatchers.Main) {
+            appListStatusLiveData.value = STATUS_START_REQUEST_CHANGE
+        }
 
         if (appList.isNullOrEmpty() || needRefresh) {
             appList = getAppsList().toMutableList()
@@ -291,10 +300,14 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             GlobalValues.shouldRequestChange.postValue(true)
         }
 
-        appListStatusLiveData.postValue(STATUS_START_REQUEST_CHANGE_END)
+        withContext(Dispatchers.Main) {
+            appListStatusLiveData.value = STATUS_START_REQUEST_CHANGE_END
+        }
         timeRecorder.end()
         Timber.d("Request change: END, $timeRecorder")
-        appListStatusLiveData.postValue(STATUS_NOT_START)
+        withContext(Dispatchers.Main) {
+            appListStatusLiveData.value = STATUS_NOT_START
+        }
 
         if (!Once.beenDone(Once.THIS_APP_VERSION, OnceTag.HAS_COLLECT_LIB)) {
             delay(10000)

--- a/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/SnapshotViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/SnapshotViewModel.kt
@@ -57,7 +57,11 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
     var compareDiffJob: Job? = null
         private set
 
-    fun compareDiff(preTimeStamp: Long, currTimeStamp: Long = CURRENT_SNAPSHOT, shouldClearDiff: Boolean = false) {
+    fun compareDiff(
+        preTimeStamp: Long,
+        currTimeStamp: Long = CURRENT_SNAPSHOT,
+        shouldClearDiff: Boolean = false
+    ) {
         if (compareDiffJob?.isActive == true) {
             compareDiffJob?.cancel()
         }
@@ -91,7 +95,8 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
 
         val context: Context = getApplication<LibCheckerApp>()
         val packageManager = context.packageManager
-        val appList: MutableList<ApplicationInfo> = AppItemRepository.getApplicationInfoItems().toMutableList()
+        val appList: MutableList<ApplicationInfo> =
+            AppItemRepository.getApplicationInfoItems().toMutableList()
         val appMap = mutableMapOf<String, ApplicationInfo>()
         val size = appList.size
         var count = 0
@@ -194,11 +199,13 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
                 diffList.add(snapshotDiffItem)
 
                 snapshotDiffContent = gson.toJson(snapshotDiffItem)
-                repository.insertSnapshotDiffItems(SnapshotDiffStoringItem(
-                    packageName = packageInfo.packageName,
-                    lastUpdatedTime = packageInfo.lastUpdateTime,
-                    diffContent = snapshotDiffContent
-                ))
+                repository.insertSnapshotDiffItems(
+                    SnapshotDiffStoringItem(
+                        packageName = packageInfo.packageName,
+                        lastUpdatedTime = packageInfo.lastUpdateTime,
+                        diffContent = snapshotDiffContent
+                    )
+                )
             }
         }
 
@@ -212,7 +219,10 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
 
                         if (snapshotDiffStoringItem != null && snapshotDiffStoringItem!!.lastUpdatedTime == packageInfo.lastUpdateTime) {
                             try {
-                                snapshotDiffItem = gson.fromJson(snapshotDiffStoringItem!!.diffContent, SnapshotDiffItem::class.java)
+                                snapshotDiffItem = gson.fromJson(
+                                    snapshotDiffStoringItem!!.diffContent,
+                                    SnapshotDiffItem::class.java
+                                )
                                 diffList.add(snapshotDiffItem)
                             } catch (e: Exception) {
                                 Timber.e(e, "diffContent parsing failed")
@@ -270,16 +280,40 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
                                 gson.toJson(PackageUtils.getNativeDirLibs(packageInfo))
                             ),
                             SnapshotDiffItem.DiffNode(
-                                gson.toJson(PackageUtils.getComponentStringList(packageInfo.packageName, SERVICE, false))
+                                gson.toJson(
+                                    PackageUtils.getComponentStringList(
+                                        packageInfo.packageName,
+                                        SERVICE,
+                                        false
+                                    )
+                                )
                             ),
                             SnapshotDiffItem.DiffNode(
-                                gson.toJson(PackageUtils.getComponentStringList(packageInfo.packageName, ACTIVITY, false))
+                                gson.toJson(
+                                    PackageUtils.getComponentStringList(
+                                        packageInfo.packageName,
+                                        ACTIVITY,
+                                        false
+                                    )
+                                )
                             ),
                             SnapshotDiffItem.DiffNode(
-                                gson.toJson(PackageUtils.getComponentStringList(packageInfo.packageName, RECEIVER, false))
+                                gson.toJson(
+                                    PackageUtils.getComponentStringList(
+                                        packageInfo.packageName,
+                                        RECEIVER,
+                                        false
+                                    )
+                                )
                             ),
                             SnapshotDiffItem.DiffNode(
-                                gson.toJson(PackageUtils.getComponentStringList(packageInfo.packageName, PROVIDER, false))
+                                gson.toJson(
+                                    PackageUtils.getComponentStringList(
+                                        packageInfo.packageName,
+                                        PROVIDER,
+                                        false
+                                    )
+                                )
                             ),
                             SnapshotDiffItem.DiffNode(
                                 gson.toJson(PackageUtils.getPermissionsList(packageInfo.packageName))
@@ -331,16 +365,31 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
                         packageName = it.packageName,
                         updateTime = it.lastUpdatedTime,
                         labelDiff = SnapshotDiffItem.DiffNode(preItem.label, it.label),
-                        versionNameDiff = SnapshotDiffItem.DiffNode(preItem.versionName, it.versionName),
-                        versionCodeDiff = SnapshotDiffItem.DiffNode(preItem.versionCode, it.versionCode),
+                        versionNameDiff = SnapshotDiffItem.DiffNode(
+                            preItem.versionName,
+                            it.versionName
+                        ),
+                        versionCodeDiff = SnapshotDiffItem.DiffNode(
+                            preItem.versionCode,
+                            it.versionCode
+                        ),
                         abiDiff = SnapshotDiffItem.DiffNode(preItem.abi, it.abi),
                         targetApiDiff = SnapshotDiffItem.DiffNode(preItem.targetApi, it.targetApi),
-                        nativeLibsDiff = SnapshotDiffItem.DiffNode(preItem.nativeLibs, it.nativeLibs),
+                        nativeLibsDiff = SnapshotDiffItem.DiffNode(
+                            preItem.nativeLibs,
+                            it.nativeLibs
+                        ),
                         servicesDiff = SnapshotDiffItem.DiffNode(preItem.services, it.services),
-                        activitiesDiff = SnapshotDiffItem.DiffNode(preItem.activities, it.activities),
+                        activitiesDiff = SnapshotDiffItem.DiffNode(
+                            preItem.activities,
+                            it.activities
+                        ),
                         receiversDiff = SnapshotDiffItem.DiffNode(preItem.receivers, it.receivers),
                         providersDiff = SnapshotDiffItem.DiffNode(preItem.providers, it.providers),
-                        permissionsDiff = SnapshotDiffItem.DiffNode(preItem.permissions, it.permissions),
+                        permissionsDiff = SnapshotDiffItem.DiffNode(
+                            preItem.permissions,
+                            it.permissions
+                        ),
                         isTrackItem = allTrackItems.any { trackItem -> trackItem.packageName == it.packageName }
                     )
                     compareDiffNode = compareNativeAndComponentDiff(snapshotDiffItem)
@@ -418,8 +467,14 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
         list.addAll(
             getNativeDiffList(
                 context,
-                gson.fromJson(entity.nativeLibsDiff.old, object : TypeToken<List<LibStringItem>>() {}.type),
-                gson.fromJson(entity.nativeLibsDiff.new, object : TypeToken<List<LibStringItem>>() {}.type)
+                gson.fromJson(
+                    entity.nativeLibsDiff.old,
+                    object : TypeToken<List<LibStringItem>>() {}.type
+                ),
+                gson.fromJson(
+                    entity.nativeLibsDiff.new,
+                    object : TypeToken<List<LibStringItem>>() {}.type
+                )
             )
         )
         list.addAll(
@@ -431,8 +486,14 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
         )
         list.addAll(
             getComponentsDiffList(
-                gson.fromJson(entity.activitiesDiff.old, object : TypeToken<List<String>>() {}.type),
-                gson.fromJson(entity.activitiesDiff.new, object : TypeToken<List<String>>() {}.type),
+                gson.fromJson(
+                    entity.activitiesDiff.old,
+                    object : TypeToken<List<String>>() {}.type
+                ),
+                gson.fromJson(
+                    entity.activitiesDiff.new,
+                    object : TypeToken<List<String>>() {}.type
+                ),
                 ACTIVITY
             )
         )
@@ -452,8 +513,14 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
         )
         list.addAll(
             getPermissionsDiffList(
-                gson.fromJson(entity.permissionsDiff.old, object : TypeToken<List<String>>() {}.type),
-                gson.fromJson(entity.permissionsDiff.new, object : TypeToken<List<String>>() {}.type)
+                gson.fromJson(
+                    entity.permissionsDiff.old,
+                    object : TypeToken<List<String>>() {}.type
+                ),
+                gson.fromJson(
+                    entity.permissionsDiff.new,
+                    object : TypeToken<List<String>>() {}.type
+                )
             )
         )
 
@@ -467,7 +534,11 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
         repository.insert(TimeStampItem(timestamp, null))
     }
 
-    private fun getNativeDiffList(context: Context, oldList: List<LibStringItem>, newList: List<LibStringItem>?): List<SnapshotDetailItem> {
+    private fun getNativeDiffList(
+        context: Context,
+        oldList: List<LibStringItem>,
+        newList: List<LibStringItem>?
+    ): List<SnapshotDetailItem> {
         val list = mutableListOf<SnapshotDetailItem>()
         if (newList == null) {
             return list
@@ -481,7 +552,18 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
             oldList.find { it.name == item.name }?.let {
                 if (it.size != item.size) {
                     list.add(
-                        SnapshotDetailItem(it.name, it.name, "${sizeToString(context, it.size)} $ARROW ${sizeToString(context, item.size)}", CHANGED, NATIVE)
+                        SnapshotDetailItem(
+                            it.name,
+                            it.name,
+                            "${sizeToString(context, it.size)} $ARROW ${
+                                sizeToString(
+                                    context,
+                                    item.size
+                                )
+                            }",
+                            CHANGED,
+                            NATIVE
+                        )
                     )
                 }
                 sameList.add(item)
@@ -495,19 +577,35 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
 
         for (item in tempOldList) {
             list.add(
-                SnapshotDetailItem(item.name, item.name, PackageUtils.sizeToString(context, item), REMOVED, NATIVE)
+                SnapshotDetailItem(
+                    item.name,
+                    item.name,
+                    PackageUtils.sizeToString(context, item),
+                    REMOVED,
+                    NATIVE
+                )
             )
         }
         for (item in tempNewList) {
             list.add(
-                SnapshotDetailItem(item.name, item.name, PackageUtils.sizeToString(context, item), ADDED, NATIVE)
+                SnapshotDetailItem(
+                    item.name,
+                    item.name,
+                    PackageUtils.sizeToString(context, item),
+                    ADDED,
+                    NATIVE
+                )
             )
         }
 
         return list
     }
 
-    private fun getComponentsDiffList(oldList: List<String>, newList: List<String>?, @LibType type: Int): List<SnapshotDetailItem> {
+    private fun getComponentsDiffList(
+        oldList: List<String>,
+        newList: List<String>?,
+        @LibType type: Int
+    ): List<SnapshotDetailItem> {
         val list = mutableListOf<SnapshotDetailItem>()
 
         if (newList == null) {
@@ -560,7 +658,10 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
         return list
     }
 
-    private fun getPermissionsDiffList(oldList: List<String>, newList: List<String>?): List<SnapshotDetailItem> {
+    private fun getPermissionsDiffList(
+        oldList: List<String>,
+        newList: List<String>?
+    ): List<SnapshotDetailItem> {
         val list = mutableListOf<SnapshotDetailItem>()
 
         if (newList == null) {
@@ -670,10 +771,13 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
         )
 
         val totalNode = CompareDiffNode()
-        totalNode.added = nativeCompareNode.added or servicesCompareNode.added or activitiesCompareNode.added or receiversCompareNode.added or providersCompareNode.added or permissionsCompareNode.added
-        totalNode.removed = nativeCompareNode.removed or servicesCompareNode.removed or activitiesCompareNode.removed or receiversCompareNode.removed or providersCompareNode.removed or permissionsCompareNode.removed
+        totalNode.added =
+            nativeCompareNode.added or servicesCompareNode.added or activitiesCompareNode.added or receiversCompareNode.added or providersCompareNode.added or permissionsCompareNode.added
+        totalNode.removed =
+            nativeCompareNode.removed or servicesCompareNode.removed or activitiesCompareNode.removed or receiversCompareNode.removed or providersCompareNode.removed or permissionsCompareNode.removed
         totalNode.changed = nativeCompareNode.changed
-        totalNode.moved = servicesCompareNode.moved or activitiesCompareNode.moved or receiversCompareNode.moved or providersCompareNode.moved
+        totalNode.moved =
+            servicesCompareNode.moved or activitiesCompareNode.moved or receiversCompareNode.moved or providersCompareNode.moved
 
         return totalNode
     }
@@ -831,25 +935,25 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
         os.close()
     }
 
-    fun restore(inputStream: InputStream, failedAction: () -> Unit) = viewModelScope.launch(Dispatchers.IO) {
-        inputStream.use {
-            val list: SnapshotList = try {
-                SnapshotList.parseFrom(inputStream)
-            } catch (e: InvalidProtocolBufferException) {
-                withContext(Dispatchers.Main) {
-                    failedAction()
+    fun restore(inputStream: InputStream, failedAction: () -> Unit) {
+        viewModelScope.launch(Dispatchers.IO) {
+            inputStream.use {
+                val list: SnapshotList = try {
+                    SnapshotList.parseFrom(inputStream)
+                } catch (e: InvalidProtocolBufferException) {
+                    withContext(Dispatchers.Main) {
+                        failedAction()
+                    }
+                    SnapshotList.newBuilder().build()
                 }
-                SnapshotList.newBuilder().build()
-            }
-            val finalList = mutableListOf<SnapshotItem>()
-            val timeStampSet = mutableSetOf<Long>()
-            var count = 0
+                val finalList = mutableListOf<SnapshotItem>()
+                val timeStampSet = mutableSetOf<Long>()
+                var count = 0
 
-            list.snapshotsList.forEach {
-                if (it != null) {
-                    timeStampSet.add(it.timeStamp)
-                    finalList.add(
-                        SnapshotItem(
+                list.snapshotsList.forEach {
+                    if (it != null) {
+                        timeStampSet += it.timeStamp
+                        finalList += SnapshotItem(
                             null,
                             it.packageName,
                             it.timeStamp,
@@ -868,22 +972,22 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
                             it.providers,
                             it.permissions
                         )
-                    )
-                    count++
+                        count++
+                    }
+
+                    if (count == 50) {
+                        repository.insertSnapshots(finalList)
+                        finalList.clear()
+                        count = 0
+                    }
                 }
 
-                if (count == 50) {
-                    repository.insertSnapshots(finalList)
-                    finalList.clear()
-                    count = 0
-                }
+                repository.insertSnapshots(finalList)
+                finalList.clear()
+                count = 0
+                timeStampSet.forEach { insertTimeStamp(it) }
+                timeStampSet.maxOrNull()?.let { GlobalValues.snapshotTimestamp = it }
             }
-
-            repository.insertSnapshots(finalList)
-            finalList.clear()
-            count = 0
-            timeStampSet.forEach { insertTimeStamp(it) }
-            timeStampSet.maxOrNull()?.let { GlobalValues.snapshotTimestamp = it }
         }
     }
 


### PR DESCRIPTION
- 删除部分没必要的协程切换的代码（主要改动在于 lifecycleScope 默认就在主线程上面启动，内部调用挂起方法之后无需再次切换主线程）
- 部分集合操作替换成中缀表达式写法，更简洁和减少代码换行

**估计这个提交会有错误的地方，一起仔细审查一下**