### PR TITLE
Make ShootService extends LifecycleService & Refine code

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,7 +148,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-common-java8:${lifecycleVersion}")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:${lifecycleVersion}")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:${lifecycleVersion}")
-    implementation("androidx.lifecycle:lifecycle-process:$lifecycleVersion")
+    implementation("androidx.lifecycle:lifecycle-service:${lifecycleVersion}")
 
     // Room components
     val roomVersion = "2.3.0"

--- a/app/src/main/kotlin/com/absinthe/libchecker/services/ShootService.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/services/ShootService.kt
@@ -3,7 +3,6 @@ package com.absinthe.libchecker.services
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.app.Service
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.res.Configuration
@@ -14,6 +13,8 @@ import android.os.RemoteException
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.lifecycleScope
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.ACTIVITY
 import com.absinthe.libchecker.annotation.PROVIDER
@@ -39,7 +40,7 @@ private const val SHOOT_CHANNEL_ID = "shoot_channel"
 private const val SHOOT_NOTIFICATION_ID = 1
 private const val SHOOT_SUCCESS_NOTIFICATION_ID = 2
 
-class ShootService : Service() {
+class ShootService : LifecycleService() {
 
     private val builder by lazy { NotificationCompat.Builder(this, SHOOT_CHANNEL_ID) }
     private val notificationManager by lazy { NotificationManagerCompat.from(this) }
@@ -57,7 +58,7 @@ class ShootService : Service() {
     private val binder = object : IShootService.Stub() {
         override fun computeSnapshot(dropPrevious: Boolean) {
             Timber.i("computeSnapshot: dropPrevious = $dropPrevious")
-            GlobalScope.launch(Dispatchers.IO) { this@ShootService.computeSnapshots(dropPrevious) }
+            lifecycleScope.launch(Dispatchers.IO) { this@ShootService.computeSnapshots(dropPrevious) }
         }
 
         override fun registerOnShootOverListener(listener: OnShootListener?) {
@@ -72,7 +73,8 @@ class ShootService : Service() {
     }
 
     @DelicateCoroutinesApi
-    override fun onBind(intent: Intent?): IBinder {
+    override fun onBind(intent: Intent): IBinder {
+        super.onBind(intent)
         return binder
     }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/services/ShootService.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/services/ShootService.kt
@@ -43,7 +43,11 @@ class ShootService : Service() {
 
     private val builder by lazy { NotificationCompat.Builder(this, SHOOT_CHANNEL_ID) }
     private val notificationManager by lazy { NotificationManagerCompat.from(this) }
-    private val configuration by lazy { Configuration(resources.configuration).apply { setLocale(GlobalValues.locale) } }
+    private val configuration by lazy {
+        Configuration(resources.configuration).apply {
+            setLocale(GlobalValues.locale)
+        }
+    }
     private val gson = Gson()
     private val repository = Repositories.lcRepository
     private val listenerList = RemoteCallbackList<OnShootListener>()
@@ -77,9 +81,9 @@ class ShootService : Service() {
         showNotification()
     }
 
-    override fun onStart(intent: Intent?, startId: Int) {
-        super.onStart(intent, startId)
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         showNotification()
+        return super.onStartCommand(intent, flags, startId)
     }
 
     private fun showNotification() {
@@ -87,7 +91,8 @@ class ShootService : Service() {
 
         notificationManager.apply {
             if (LCAppUtils.atLeastO()) {
-                val name = createConfigurationContext(configuration).resources.getString(R.string.channel_shoot)
+                val name = createConfigurationContext(configuration).resources
+                    .getString(R.string.channel_shoot)
                 val importance = NotificationManager.IMPORTANCE_DEFAULT
                 val mChannel = NotificationChannel(SHOOT_CHANNEL_ID, name, importance)
                 createNotificationChannel(mChannel)
@@ -230,11 +235,21 @@ class ShootService : Service() {
                             isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) == ApplicationInfo.FLAG_SYSTEM,
                             abi = abiValue.toShort(),
                             targetApi = info.targetSdkVersion.toShort(),
-                            nativeLibs = gson.toJson(PackageUtils.getNativeDirLibs(it, PackageUtils.is32bit(abiValue))),
-                            services = gson.toJson(PackageUtils.getComponentStringList(it.packageName, SERVICE, false)),
-                            activities = gson.toJson(PackageUtils.getComponentStringList(it.packageName, ACTIVITY, false)),
-                            receivers = gson.toJson(PackageUtils.getComponentStringList(it.packageName, RECEIVER, false)),
-                            providers = gson.toJson(PackageUtils.getComponentStringList(it.packageName, PROVIDER, false)),
+                            nativeLibs = gson.toJson(
+                                PackageUtils.getNativeDirLibs(it, PackageUtils.is32bit(abiValue))
+                            ),
+                            services = gson.toJson(
+                                PackageUtils.getComponentStringList(it.packageName, SERVICE, false)
+                            ),
+                            activities = gson.toJson(
+                                PackageUtils.getComponentStringList(it.packageName, ACTIVITY, false)
+                            ),
+                            receivers = gson.toJson(
+                                PackageUtils.getComponentStringList(it.packageName, RECEIVER, false)
+                            ),
+                            providers = gson.toJson(
+                                PackageUtils.getComponentStringList(it.packageName, PROVIDER, false)
+                            ),
                             permissions = gson.toJson(PackageUtils.getPermissionsList(it.packageName))
                         )
                     )
@@ -283,9 +298,10 @@ class ShootService : Service() {
 
     private fun initBuilder() {
         val pi = PendingIntent.getActivity(
-            this, 0, Intent(this, MainActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            }, PendingIntent.FLAG_IMMUTABLE
+            this,
+            0,
+            Intent(this, MainActivity::class.java).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            PendingIntent.FLAG_IMMUTABLE
         )
         builder.setContentTitle(createConfigurationContext(configuration).resources.getString(R.string.noti_shoot_title))
             .setSmallIcon(R.drawable.ic_logo)


### PR DESCRIPTION
- 让 `ShootService` 继承 `LifecycleService`，替换内部的协程域为 `lifecycleScope`，使用更安全
- 部分写法优化