### PR TITLE
Refactor BaseActivity & BaseFragment

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/base/BaseActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/base/BaseActivity.kt
@@ -1,4 +1,4 @@
-package com.absinthe.libchecker
+package com.absinthe.libchecker.base
 
 import android.annotation.SuppressLint
 import android.content.res.Resources
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.view.ViewGroup
+import com.absinthe.libchecker.R
 import com.absinthe.libchecker.constant.GlobalValues
 import rikka.material.app.MaterialActivity
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/base/BaseActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/base/BaseActivity.kt
@@ -5,21 +5,21 @@ import android.content.res.Resources
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
-import android.view.ViewGroup
+import androidx.viewbinding.ViewBinding
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.constant.GlobalValues
+import com.absinthe.libchecker.utils.extensions.inflateBinding
 import rikka.material.app.MaterialActivity
 
 @SuppressLint("Registered, MissingSuperCall")
-abstract class BaseActivity : MaterialActivity() {
+abstract class BaseActivity<VB : ViewBinding> : MaterialActivity() {
 
-  protected var root: ViewGroup? = null
-
-  protected abstract fun setViewBinding(): ViewGroup
+  protected lateinit var binding: VB
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setViewBindingImpl(setViewBinding())
+    binding = inflateBinding(layoutInflater)
+    setContentView(binding.root)
   }
 
   override fun shouldApplyTranslucentSystemBars(): Boolean {
@@ -47,10 +47,5 @@ abstract class BaseActivity : MaterialActivity() {
     if (GlobalValues.rengeTheme) {
       theme.applyStyle(R.style.ThemeOverlay_Renge, true)
     }
-  }
-
-  private fun setViewBindingImpl(root: ViewGroup) {
-    this.root = root
-    setContentView(root)
   }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/base/BaseBottomSheetViewDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/base/BaseBottomSheetViewDialogFragment.kt
@@ -1,4 +1,4 @@
-package com.absinthe.libchecker.ui.fragment
+package com.absinthe.libchecker.base
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/kotlin/com/absinthe/libchecker/base/BaseFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/base/BaseFragment.kt
@@ -1,37 +1,50 @@
 package com.absinthe.libchecker.base
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.CallSuper
 import androidx.fragment.app.Fragment
 import androidx.viewbinding.ViewBinding
+import com.absinthe.libchecker.utils.extensions.inflateBinding
 import timber.log.Timber
 
-abstract class BaseFragment<T : ViewBinding>(layoutId: Int) : Fragment(layoutId) {
+abstract class BaseFragment<VB : ViewBinding> : Fragment() {
 
-  private var _binding: T? = null
-  val binding get() = _binding!!
+  protected lateinit var binding: VB
 
   private var parentActivityVisible = false
   private var visible = false
-  private var localParentFragment: BaseFragment<T>? = null
+  private var localParentFragment: BaseFragment<VB>? = null
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     Timber.d("${javaClass.simpleName} ==> onViewCreated")
-    _binding = initBinding(view)
     init()
   }
 
-  abstract fun initBinding(view: View): T
   abstract fun init()
 
   open fun onVisibilityChanged(visible: Boolean) {
     Timber.d("${javaClass.simpleName} ==> onVisibilityChanged = $visible")
   }
 
+  @CallSuper
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    binding = inflateBinding(layoutInflater)
+  }
+
+  @CallSuper
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View = binding.root
+
   override fun onDestroyView() {
     Timber.d("${javaClass.simpleName} ==> onDestroyView")
-    _binding = null
     super.onDestroyView()
   }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/base/BaseFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/base/BaseFragment.kt
@@ -1,4 +1,4 @@
-package com.absinthe.libchecker.ui.fragment
+package com.absinthe.libchecker.base
 
 import android.os.Bundle
 import android.view.View

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
@@ -73,7 +73,7 @@ class SnapshotComponentProvider(val lifecycleScope: LifecycleCoroutineScope) : B
             LibDetailDialogFragment.newInstance(name, item.item.itemType, regexName)
               .apply {
                 show(
-                  (this@SnapshotComponentProvider.context as BaseActivity).supportFragmentManager,
+                  (this@SnapshotComponentProvider.context as BaseActivity<*>).supportFragmentManager,
                   tag
                 )
               }

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
@@ -6,8 +6,8 @@ import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleCoroutineScope
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.bean.ADDED
 import com.absinthe.libchecker.bean.CHANGED
 import com.absinthe.libchecker.bean.MOVED

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
@@ -72,7 +72,7 @@ class SnapshotNativeProvider(val lifecycleScope: LifecycleCoroutineScope) : Base
             LibDetailDialogFragment.newInstance(name, item.item.itemType, regexName)
               .apply {
                 show(
-                  (this@SnapshotNativeProvider.context as BaseActivity).supportFragmentManager,
+                  (this@SnapshotNativeProvider.context as BaseActivity<*>).supportFragmentManager,
                   tag
                 )
               }

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
@@ -6,9 +6,9 @@ import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleCoroutineScope
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.NATIVE
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.bean.ADDED
 import com.absinthe.libchecker.bean.CHANGED
 import com.absinthe.libchecker.bean.REMOVED

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
@@ -52,7 +52,7 @@ class BackupActivity : BaseActivity<ActivityBackupBinding>() {
 
   class BackupFragment : PreferenceFragmentCompat() {
 
-    private val viewModel by viewModels<SnapshotViewModel>()
+    private val viewModel: SnapshotViewModel by viewModels()
 
     private lateinit var backupResultLauncher: ActivityResultLauncher<String>
     private lateinit var restoreResultLauncher: ActivityResultLauncher<String>

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
@@ -28,14 +28,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-class BackupActivity : BaseActivity() {
-
-  private lateinit var binding: ActivityBackupBinding
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivityBackupBinding.inflate(layoutInflater)
-    return binding.root
-  }
+class BackupActivity : BaseActivity<ActivityBackupBinding>() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -144,7 +137,7 @@ class BackupActivity : BaseActivity() {
 
       recyclerView.borderViewDelegate.borderVisibilityChangedListener =
         BorderView.OnBorderVisibilityChangedListener { top: Boolean, _: Boolean, _: Boolean, _: Boolean ->
-          (activity as BaseActivity?)?.appBar?.setRaised(!top)
+          (activity as? BaseActivity<*>)?.appBar?.setRaised(!top)
         }
       return recyclerView
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
@@ -12,8 +12,8 @@ import androidx.fragment.app.viewModels
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.recyclerview.widget.RecyclerView
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.databinding.ActivityBackupBinding
 import com.absinthe.libchecker.utils.StorageUtils

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
@@ -35,18 +35,12 @@ import rikka.widget.borderview.BorderView
 const val VF_LOADING = 0
 const val VF_LIST = 1
 
-class ComparisonActivity : BaseActivity() {
+class ComparisonActivity : BaseActivity<ActivityComparisonBinding>() {
 
-  private lateinit var binding: ActivityComparisonBinding
   private val viewModel by viewModels<SnapshotViewModel>()
   private val adapter by unsafeLazy { SnapshotAdapter(lifecycleScope) }
   private var leftTimeStamp = 0L
   private var rightTimeStamp = 0L
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivityComparisonBinding.inflate(layoutInflater)
-    return binding.root
-  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
@@ -37,7 +37,7 @@ const val VF_LIST = 1
 
 class ComparisonActivity : BaseActivity<ActivityComparisonBinding>() {
 
-  private val viewModel by viewModels<SnapshotViewModel>()
+  private val viewModel: SnapshotViewModel by viewModels()
   private val adapter by unsafeLazy { SnapshotAdapter(lifecycleScope) }
   private var leftTimeStamp = 0L
   private var rightTimeStamp = 0L

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
@@ -13,8 +13,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.databinding.ActivityComparisonBinding
 import com.absinthe.libchecker.databinding.LayoutComparisonDashboardBinding
 import com.absinthe.libchecker.recyclerview.HorizontalSpacesItemDecoration

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
@@ -12,8 +12,8 @@ import android.widget.FrameLayout
 import androidx.appcompat.widget.SearchView
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.bean.TrackListItem
 import com.absinthe.libchecker.database.AppItemRepository
 import com.absinthe.libchecker.database.Repositories

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
@@ -31,19 +31,13 @@ import kotlinx.coroutines.withContext
 import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import rikka.widget.borderview.BorderView
 
-class TrackActivity : BaseActivity(), SearchView.OnQueryTextListener {
+class TrackActivity : BaseActivity<ActivityTrackBinding>(), SearchView.OnQueryTextListener {
 
-  private lateinit var binding: ActivityTrackBinding
   private val repository = Repositories.lcRepository
   private val adapter by unsafeLazy { TrackAdapter(lifecycleScope) }
   private val list = mutableListOf<TrackListItem>()
   private var menu: Menu? = null
   private var isListReady = false
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivityTrackBinding.inflate(layoutInflater)
-    return binding.root
-  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/app/CheckPackageOnResumingActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/app/CheckPackageOnResumingActivity.kt
@@ -1,10 +1,11 @@
 package com.absinthe.libchecker.ui.app
 
 import android.content.pm.PackageManager
+import androidx.viewbinding.ViewBinding
 import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.utils.PackageUtils
 
-abstract class CheckPackageOnResumingActivity : BaseActivity() {
+abstract class CheckPackageOnResumingActivity<VB : ViewBinding> : BaseActivity<VB>() {
   abstract fun requirePackageName(): String?
 
   override fun onResume() {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/app/CheckPackageOnResumingActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/app/CheckPackageOnResumingActivity.kt
@@ -1,7 +1,7 @@
 package com.absinthe.libchecker.ui.app
 
 import android.content.pm.PackageManager
-import com.absinthe.libchecker.BaseActivity
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.utils.PackageUtils
 
 abstract class CheckPackageOnResumingActivity : BaseActivity() {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
@@ -54,7 +54,7 @@ class ApkDetailActivity : BaseActivity<ActivityAppDetailBinding>(), IDetailConta
 
   private var tempFile: File? = null
 
-  private val viewModel by viewModels<DetailViewModel>()
+  private val viewModel: DetailViewModel by viewModels()
 
   override var detailFragmentManager: DetailFragmentManager = DetailFragmentManager()
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
@@ -17,7 +17,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import coil.load
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.ACTIVITY
 import com.absinthe.libchecker.annotation.DEX
@@ -26,6 +25,7 @@ import com.absinthe.libchecker.annotation.PROVIDER
 import com.absinthe.libchecker.annotation.RECEIVER
 import com.absinthe.libchecker.annotation.SERVICE
 import com.absinthe.libchecker.annotation.STATIC
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.databinding.ActivityAppDetailBinding
 import com.absinthe.libchecker.ui.fragment.detail.DetailFragmentManager

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
@@ -10,7 +10,6 @@ import android.text.SpannableStringBuilder
 import android.text.style.ImageSpan
 import android.text.style.StrikethroughSpan
 import android.view.MenuItem
-import android.view.ViewGroup
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
@@ -51,19 +50,13 @@ import timber.log.Timber
 import java.io.File
 import java.io.InputStream
 
-class ApkDetailActivity : BaseActivity(), IDetailContainer {
+class ApkDetailActivity : BaseActivity<ActivityAppDetailBinding>(), IDetailContainer {
 
-  private lateinit var binding: ActivityAppDetailBinding
   private var tempFile: File? = null
 
   private val viewModel by viewModels<DetailViewModel>()
 
   override var detailFragmentManager: DetailFragmentManager = DetailFragmentManager()
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivityAppDetailBinding.inflate(layoutInflater)
-    return binding.root
-  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
@@ -13,7 +13,6 @@ import android.text.SpannableStringBuilder
 import android.text.style.ImageSpan
 import android.text.style.StrikethroughSpan
 import android.view.MenuItem
-import android.view.ViewGroup
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
@@ -69,9 +68,8 @@ import java.io.File
 const val EXTRA_PACKAGE_NAME = "android.intent.extra.PACKAGE_NAME"
 const val EXTRA_DETAIL_BEAN = "EXTRA_DETAIL_BEAN"
 
-class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
+class AppDetailActivity : CheckPackageOnResumingActivity<ActivityAppDetailBinding>(), IDetailContainer {
 
-  private lateinit var binding: ActivityAppDetailBinding
   private val pkgName by unsafeLazy { intent.getStringExtra(EXTRA_PACKAGE_NAME) }
   private val refName by unsafeLazy { intent.getStringExtra(EXTRA_REF_NAME) }
   private val refType by unsafeLazy { intent.getIntExtra(EXTRA_REF_TYPE, ALL) }
@@ -84,11 +82,6 @@ class AppDetailActivity : CheckPackageOnResumingActivity(), IDetailContainer {
   override var detailFragmentManager: DetailFragmentManager = DetailFragmentManager()
 
   override fun requirePackageName() = pkgName
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivityAppDetailBinding.inflate(layoutInflater)
-    return binding.root
-  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
@@ -13,7 +13,6 @@ import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.SimpleItemAnimator
 import coil.load
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.ACTIVITY
 import com.absinthe.libchecker.annotation.NATIVE
@@ -21,6 +20,7 @@ import com.absinthe.libchecker.annotation.PERMISSION
 import com.absinthe.libchecker.annotation.PROVIDER
 import com.absinthe.libchecker.annotation.RECEIVER
 import com.absinthe.libchecker.annotation.SERVICE
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.bean.DetailExtraBean
 import com.absinthe.libchecker.bean.REMOVED
 import com.absinthe.libchecker.bean.SnapshotDetailItem

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
@@ -58,7 +58,7 @@ class SnapshotDetailActivity : BaseActivity<ActivitySnapshotDetailBinding>() {
   private lateinit var entity: SnapshotDiffItem
 
   private val adapter by unsafeLazy { SnapshotDetailAdapter(lifecycleScope) }
-  private val viewModel by viewModels<SnapshotViewModel>()
+  private val viewModel: SnapshotViewModel by viewModels()
   private val _entity by unsafeLazy { intent.getSerializableExtra(EXTRA_ENTITY) as? SnapshotDiffItem }
 
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
@@ -6,7 +6,6 @@ import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.Gravity
 import android.view.MenuItem
-import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.activity.viewModels
 import androidx.core.os.bundleOf
@@ -54,19 +53,13 @@ import me.zhanghai.android.appiconloader.AppIconLoader
 
 const val EXTRA_ENTITY = "EXTRA_ENTITY"
 
-class SnapshotDetailActivity : BaseActivity() {
+class SnapshotDetailActivity : BaseActivity<ActivitySnapshotDetailBinding>() {
 
-  private lateinit var binding: ActivitySnapshotDetailBinding
   private lateinit var entity: SnapshotDiffItem
 
   private val adapter by unsafeLazy { SnapshotDetailAdapter(lifecycleScope) }
   private val viewModel by viewModels<SnapshotViewModel>()
   private val _entity by unsafeLazy { intent.getSerializableExtra(EXTRA_ENTITY) as? SnapshotDiffItem }
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivitySnapshotDetailBinding.inflate(layoutInflater)
-    return binding.root
-  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseDetailFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseDetailFragment.kt
@@ -41,7 +41,7 @@ const val EXTRA_TYPE = "EXTRA_TYPE"
 
 abstract class BaseDetailFragment<T : ViewBinding> : BaseFragment<T>(), Sortable {
 
-  protected val viewModel by activityViewModels<DetailViewModel>()
+  protected val viewModel: DetailViewModel by activityViewModels()
   protected val packageName by lazy { arguments?.getString(EXTRA_PACKAGE_NAME).orEmpty() }
   protected val type by lazy { arguments?.getInt(EXTRA_TYPE) ?: NATIVE }
   protected val adapter by lazy { LibStringAdapter(type) }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseDetailFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseDetailFragment.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import androidx.viewbinding.ViewBinding
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.NATIVE
+import com.absinthe.libchecker.base.BaseFragment
 import com.absinthe.libchecker.bean.LibStringItemChip
 import com.absinthe.libchecker.recyclerview.adapter.detail.LibStringAdapter
 import com.absinthe.libchecker.ui.detail.EXTRA_PACKAGE_NAME

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseDetailFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseDetailFragment.kt
@@ -39,9 +39,7 @@ import timber.log.Timber
 
 const val EXTRA_TYPE = "EXTRA_TYPE"
 
-abstract class BaseDetailFragment<T : ViewBinding>(layoutId: Int) :
-  BaseFragment<T>(layoutId),
-  Sortable {
+abstract class BaseDetailFragment<T : ViewBinding> : BaseFragment<T>(), Sortable {
 
   protected val viewModel by activityViewModels<DetailViewModel>()
   protected val packageName by lazy { arguments?.getString(EXTRA_PACKAGE_NAME).orEmpty() }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
@@ -12,7 +12,7 @@ import rikka.widget.borderview.BorderViewDelegate
 abstract class BaseListControllerFragment<T : ViewBinding> : BaseFragment<T>(), IListController {
 
   protected var borderDelegate: BorderViewDelegate? = null
-  protected val homeViewModel by activityViewModels<HomeViewModel>()
+  protected val homeViewModel: HomeViewModel by activityViewModels()
   protected var isListReady = false
   protected var allowRefreshing = true
   protected var menu: Menu? = null

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
@@ -9,8 +9,7 @@ import com.absinthe.libchecker.viewmodel.HomeViewModel
 import rikka.material.app.AppBar
 import rikka.widget.borderview.BorderViewDelegate
 
-abstract class BaseListControllerFragment<T : ViewBinding>(layoutId: Int) :
-  BaseFragment<T>(layoutId), IListController {
+abstract class BaseListControllerFragment<T : ViewBinding> : BaseFragment<T>(), IListController {
 
   protected var borderDelegate: BorderViewDelegate? = null
   protected val homeViewModel by activityViewModels<HomeViewModel>()

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
@@ -6,6 +6,7 @@ import androidx.viewbinding.ViewBinding
 import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.base.BaseFragment
 import com.absinthe.libchecker.viewmodel.HomeViewModel
+import rikka.material.app.AppBar
 import rikka.widget.borderview.BorderViewDelegate
 
 abstract class BaseListControllerFragment<T : ViewBinding>(layoutId: Int) :
@@ -39,13 +40,13 @@ abstract class BaseListControllerFragment<T : ViewBinding>(layoutId: Int) :
     }
   }
 
-  override fun getAppBar() = (activity as? BaseActivity<*>)?.appBar
+  override fun getAppBar(): AppBar? = (activity as? BaseActivity<*>)?.appBar
 
-  override fun getBorderViewDelegate() = borderDelegate
+  override fun getBorderViewDelegate(): BorderViewDelegate? = borderDelegate
 
   override fun scheduleAppbarRaisingStatus() {
     getAppBar()?.setRaised(!(getBorderViewDelegate()?.isShowingTopBorder ?: true))
   }
 
-  override fun isAllowRefreshing() = allowRefreshing
+  override fun isAllowRefreshing(): Boolean = allowRefreshing
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
@@ -39,7 +39,7 @@ abstract class BaseListControllerFragment<T : ViewBinding>(layoutId: Int) :
     }
   }
 
-  override fun getAppBar() = (activity as BaseActivity?)?.appBar
+  override fun getAppBar() = (activity as? BaseActivity<*>)?.appBar
 
   override fun getBorderViewDelegate() = borderDelegate
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/BaseListControllerFragment.kt
@@ -3,7 +3,8 @@ package com.absinthe.libchecker.ui.fragment
 import android.view.Menu
 import androidx.fragment.app.activityViewModels
 import androidx.viewbinding.ViewBinding
-import com.absinthe.libchecker.BaseActivity
+import com.absinthe.libchecker.base.BaseActivity
+import com.absinthe.libchecker.base.BaseFragment
 import com.absinthe.libchecker.viewmodel.HomeViewModel
 import rikka.widget.borderview.BorderViewDelegate
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/applist/AppListFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/applist/AppListFragment.kt
@@ -57,7 +57,7 @@ const val VF_LIST = 1
 const val VF_INIT = 2
 
 class AppListFragment :
-  BaseListControllerFragment<FragmentAppListBinding>(R.layout.fragment_app_list),
+  BaseListControllerFragment<FragmentAppListBinding>(),
   SearchView.OnQueryTextListener {
 
   private val mAdapter by lazy { AppAdapter(lifecycleScope) }
@@ -65,8 +65,6 @@ class AppListFragment :
   private var popup: PopupMenu? = null
 
   private lateinit var layoutManager: RecyclerView.LayoutManager
-
-  override fun initBinding(view: View): FragmentAppListBinding = FragmentAppListBinding.bind(view)
 
   override fun init() {
     setHasOptionsMenu(true)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/AppBundleBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/AppBundleBottomSheetDialogFragment.kt
@@ -2,9 +2,9 @@ package com.absinthe.libchecker.ui.fragment.detail
 
 import android.view.ViewGroup
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.bean.AppBundleItemBean
 import com.absinthe.libchecker.ui.detail.EXTRA_PACKAGE_NAME
-import com.absinthe.libchecker.ui.fragment.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.utils.PackageUtils
 import com.absinthe.libchecker.utils.extensions.dp
 import com.absinthe.libchecker.view.app.BottomSheetHeaderView

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/AppInfoBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/AppInfoBottomSheetDialogFragment.kt
@@ -36,6 +36,7 @@ class AppInfoBottomSheetDialogFragment :
   private val mAdapter = AppInfoAdapter()
 
   override fun initRootView(): AppInfoBottomSheetView = AppInfoBottomSheetView(requireContext())
+
   override fun getHeaderView(): BottomSheetHeaderView = root.getHeaderView()
 
   override fun init() {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/AppInfoBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/AppInfoBottomSheetDialogFragment.kt
@@ -13,9 +13,9 @@ import androidx.annotation.RequiresApi
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import com.absinthe.libchecker.BuildConfig
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.recyclerview.adapter.detail.AppInfoAdapter
 import com.absinthe.libchecker.ui.detail.EXTRA_PACKAGE_NAME
-import com.absinthe.libchecker.ui.fragment.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.utils.LCAppUtils
 import com.absinthe.libchecker.utils.extensions.dp
 import com.absinthe.libchecker.utils.showToast

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/LibDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/LibDetailDialogFragment.kt
@@ -31,11 +31,10 @@ class LibDetailDialogFragment : BaseBottomSheetViewDialogFragment<LibDetailBotto
   private val libName by lazy { arguments?.getString(EXTRA_LIB_NAME).orEmpty() }
   private val type by lazy { arguments?.getInt(EXTRA_LIB_TYPE) ?: NATIVE }
   private val regexName by lazy { arguments?.getString(EXTRA_REGEX_NAME) }
-  private val viewModel by activityViewModels<DetailViewModel>()
+  private val viewModel: DetailViewModel by activityViewModels()
   private var isStickyEventReceived = false
 
-  override fun initRootView(): LibDetailBottomSheetView =
-    LibDetailBottomSheetView(requireContext())
+  override fun initRootView(): LibDetailBottomSheetView = LibDetailBottomSheetView(requireContext())
 
   override fun init() {
     root.apply {
@@ -59,7 +58,7 @@ class LibDetailDialogFragment : BaseBottomSheetViewDialogFragment<LibDetailBotto
 
   override fun onStart() {
     super.onStart()
-    viewModel.detailBean.observe(this) {
+    viewModel.detailBean.observe(viewLifecycleOwner) {
       if (it != null) {
         root.apply {
           libDetailContentView.apply {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/LibDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/LibDetailDialogFragment.kt
@@ -10,8 +10,8 @@ import coil.load
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.LibType
 import com.absinthe.libchecker.annotation.NATIVE
+import com.absinthe.libchecker.base.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.constant.librarymap.IconResMap
-import com.absinthe.libchecker.ui.fragment.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.utils.LCAppUtils
 import com.absinthe.libchecker.utils.extensions.putArguments
 import com.absinthe.libchecker.view.app.BottomSheetHeaderView

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/AbilityAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/AbilityAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.view.View
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.absinthe.libchecker.R
@@ -23,12 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import rikka.core.util.ClipboardUtils
 
-class AbilityAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>(
-  R.layout.fragment_lib_component
-) {
-
-  override fun initBinding(view: View): FragmentLibComponentBinding =
-    FragmentLibComponentBinding.bind(view)
+class AbilityAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>() {
 
   override fun getRecyclerView() = binding.list
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/ComponentsAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/ComponentsAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.view.View
 import android.widget.ArrayAdapter
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
@@ -33,16 +32,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import rikka.core.util.ClipboardUtils
 
-class ComponentsAnalysisFragment :
-  BaseDetailFragment<FragmentLibComponentBinding>(R.layout.fragment_lib_component) {
+class ComponentsAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>() {
 
   private val hasIntegration by lazy {
     !viewModel.isApk && (MonkeyKingManager.isSupportInteraction || (AnywhereManager.isSupportInteraction && type == ACTIVITY))
   }
   private var integrationMonkeyKingBlockList: List<ShareCmpInfo.Component>? = null
-
-  override fun initBinding(view: View): FragmentLibComponentBinding =
-    FragmentLibComponentBinding.bind(view)
 
   override fun getRecyclerView() = binding.list
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/DexAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/DexAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.view.View
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.LibType
@@ -17,11 +16,7 @@ import com.absinthe.libchecker.utils.showToast
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import rikka.core.util.ClipboardUtils
 
-class DexAnalysisFragment :
-  BaseDetailFragment<FragmentLibComponentBinding>(R.layout.fragment_lib_component) {
-
-  override fun initBinding(view: View): FragmentLibComponentBinding =
-    FragmentLibComponentBinding.bind(view)
+class DexAnalysisFragment : BaseDetailFragment<FragmentLibComponentBinding>() {
 
   override fun getRecyclerView() = binding.list
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/NativeAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/NativeAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.view.View
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.LibType
 import com.absinthe.libchecker.databinding.FragmentLibNativeBinding
@@ -16,11 +15,7 @@ import com.absinthe.libchecker.utils.showToast
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import rikka.core.util.ClipboardUtils
 
-class NativeAnalysisFragment :
-  BaseDetailFragment<FragmentLibNativeBinding>(R.layout.fragment_lib_native) {
-
-  override fun initBinding(view: View): FragmentLibNativeBinding =
-    FragmentLibNativeBinding.bind(view)
+class NativeAnalysisFragment : BaseDetailFragment<FragmentLibNativeBinding>() {
 
   override fun getRecyclerView() = binding.list
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/StaticAnalysisFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/detail/impl/StaticAnalysisFragment.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.ui.fragment.detail.impl
 
-import android.view.View
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.LibType
 import com.absinthe.libchecker.databinding.FragmentLibNativeBinding
@@ -16,11 +15,7 @@ import com.absinthe.libchecker.utils.showToast
 import com.absinthe.libraries.utils.utils.AntiShakeUtils
 import rikka.core.util.ClipboardUtils
 
-class StaticAnalysisFragment :
-  BaseDetailFragment<FragmentLibNativeBinding>(R.layout.fragment_lib_native) {
-
-  override fun initBinding(view: View): FragmentLibNativeBinding =
-    FragmentLibNativeBinding.bind(view)
+class StaticAnalysisFragment : BaseDetailFragment<FragmentLibNativeBinding>() {
 
   override fun getRecyclerView() = binding.list
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/CloudRulesDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/CloudRulesDialogFragment.kt
@@ -6,10 +6,10 @@ import androidx.lifecycle.lifecycleScope
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.api.ApiManager
 import com.absinthe.libchecker.api.request.CloudRuleBundleRequest
+import com.absinthe.libchecker.base.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.database.RuleDatabase
-import com.absinthe.libchecker.ui.fragment.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.utils.DownloadUtils
 import com.absinthe.libchecker.utils.extensions.addPaddingTop
 import com.absinthe.libchecker.utils.extensions.dp

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/CloudRulesDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/CloudRulesDialogFragment.kt
@@ -26,6 +26,7 @@ class CloudRulesDialogFragment : BaseBottomSheetViewDialogFragment<CloudRulesDia
   private val request: CloudRuleBundleRequest = ApiManager.create()
 
   override fun initRootView(): CloudRulesDialogView = CloudRulesDialogView(requireContext())
+
   override fun getHeaderView(): BottomSheetHeaderView = root.getHeaderView()
 
   override fun init() {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/SettingsFragment.kt
@@ -33,6 +33,7 @@ import com.absinthe.libchecker.viewmodel.HomeViewModel
 import com.absinthe.libraries.utils.utils.UiUtils
 import com.microsoft.appcenter.analytics.Analytics
 import com.microsoft.appcenter.analytics.EventProperties
+import rikka.material.app.AppBar
 import rikka.material.app.DayNightDelegate
 import rikka.material.app.LocaleDelegate
 import rikka.preference.SimpleMenuPreference
@@ -317,13 +318,13 @@ class SettingsFragment : PreferenceFragmentCompat(), IListController {
     // Do nothing
   }
 
-  override fun getAppBar() = (activity as MainActivity?)?.appBar
+  override fun getAppBar(): AppBar? = (activity as MainActivity?)?.appBar
 
-  override fun getBorderViewDelegate() = borderViewDelegate
+  override fun getBorderViewDelegate(): BorderViewDelegate = borderViewDelegate
 
   override fun scheduleAppbarRaisingStatus() {
     getAppBar()?.setRaised(!getBorderViewDelegate().isShowingTopBorder)
   }
 
-  override fun isAllowRefreshing() = true
+  override fun isAllowRefreshing(): Boolean = true
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/settings/SettingsFragment.kt
@@ -48,7 +48,7 @@ import java.util.Locale
 class SettingsFragment : PreferenceFragmentCompat(), IListController {
 
   private lateinit var borderViewDelegate: BorderViewDelegate
-  private val viewModel by activityViewModels<HomeViewModel>()
+  private val viewModel: HomeViewModel by activityViewModels()
 
   companion object {
     init {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
@@ -21,8 +21,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.database.AppItemRepository

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
@@ -60,7 +60,7 @@ const val VF_LIST = 1
 
 class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>() {
 
-  private val viewModel by activityViewModels<SnapshotViewModel>()
+  private val viewModel: SnapshotViewModel by activityViewModels()
   private val adapter by unsafeLazy { SnapshotAdapter(lifecycleScope) }
   private var isSnapshotDatabaseItemsReady = false
   private var dropPrevious = false

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
@@ -11,7 +11,6 @@ import android.view.Gravity
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
-import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.appcompat.app.AlertDialog
@@ -59,9 +58,7 @@ import rikka.widget.borderview.BorderView
 const val VF_LOADING = 0
 const val VF_LIST = 1
 
-class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(
-  R.layout.fragment_snapshot
-) {
+class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>() {
 
   private val viewModel by activityViewModels<SnapshotViewModel>()
   private val adapter by unsafeLazy { SnapshotAdapter(lifecycleScope) }
@@ -102,9 +99,6 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(
       shootBinder = null
     }
   }
-
-  override fun initBinding(view: View): FragmentSnapshotBinding =
-    FragmentSnapshotBinding.bind(view)
 
   override fun init() {
     setHasOptionsMenu(true)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/SnapshotFragment.kt
@@ -190,7 +190,7 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(
         layoutManager = getSuitableLayoutManager()
         borderVisibilityChangedListener =
           BorderView.OnBorderVisibilityChangedListener { top: Boolean, _: Boolean, _: Boolean, _: Boolean ->
-            (requireActivity() as BaseActivity).appBar?.setRaised(!top)
+            (requireActivity() as BaseActivity<*>).appBar?.setRaised(!top)
           }
 
         if (itemDecorationCount == 0) {
@@ -343,7 +343,7 @@ class SnapshotFragment : BaseListControllerFragment<FragmentSnapshotBinding>(
     }
     if (child == VF_LOADING) {
       binding.loading.resumeAnimation()
-      (requireActivity() as BaseActivity).appBar?.setRaised(false)
+      (requireActivity() as BaseActivity<*>).appBar?.setRaised(false)
     } else {
       binding.loading.pauseAnimation()
       binding.list.scrollToPosition(0)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/TimeNodeBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/TimeNodeBottomSheetDialogFragment.kt
@@ -20,6 +20,7 @@ class TimeNodeBottomSheetDialogFragment :
   private var customTitle: String? = null
 
   override fun initRootView(): TimeNodeBottomSheetView = TimeNodeBottomSheetView(requireContext())
+
   override fun getHeaderView(): BottomSheetHeaderView = headerView
 
   override fun init() {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/TimeNodeBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/snapshot/TimeNodeBottomSheetDialogFragment.kt
@@ -2,8 +2,8 @@ package com.absinthe.libchecker.ui.fragment.snapshot
 
 import android.view.ViewGroup
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.database.entity.TimeStampItem
-import com.absinthe.libchecker.ui.fragment.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.utils.extensions.dp
 import com.absinthe.libchecker.utils.extensions.putArguments
 import com.absinthe.libchecker.view.app.BottomSheetHeaderView

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
@@ -52,7 +52,7 @@ class ChartFragment :
   OnChartValueSelectedListener,
   MaterialButtonToggleGroup.OnButtonCheckedListener {
 
-  private val viewModel by activityViewModels<HomeViewModel>()
+  private val viewModel: HomeViewModel by activityViewModels()
   private val legendList = mutableListOf<String>()
   private val existApiList = mutableListOf<Int>()
   private var chartType = TYPE_ABI

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseFragment
 import com.absinthe.libchecker.constant.Constants.ARMV5
 import com.absinthe.libchecker.constant.Constants.ARMV7
 import com.absinthe.libchecker.constant.Constants.ARMV8
@@ -19,7 +20,6 @@ import com.absinthe.libchecker.constant.Constants.NO_LIBS
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.database.entity.LCItem
 import com.absinthe.libchecker.databinding.FragmentPieChartBinding
-import com.absinthe.libchecker.ui.fragment.BaseFragment
 import com.absinthe.libchecker.utils.PackageUtils
 import com.absinthe.libchecker.utils.extensions.isShowing
 import com.absinthe.libchecker.view.statistics.IntegerFormatter

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
@@ -5,7 +5,6 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Build
 import android.view.HapticFeedbackConstants
-import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
@@ -49,7 +48,7 @@ private const val TYPE_KOTLIN = 1
 private const val TYPE_TARGET_API = 2
 
 class ChartFragment :
-  BaseFragment<FragmentPieChartBinding>(R.layout.fragment_pie_chart),
+  BaseFragment<FragmentPieChartBinding>(),
   OnChartValueSelectedListener,
   MaterialButtonToggleGroup.OnButtonCheckedListener {
 
@@ -59,9 +58,6 @@ class ChartFragment :
   private var chartType = TYPE_ABI
   private var mDialog: ClassifyBottomSheetDialogFragment? = null
   private lateinit var chartView: ViewGroup
-
-  override fun initBinding(view: View): FragmentPieChartBinding =
-    FragmentPieChartBinding.bind(view)
 
   override fun init() {
     chartView = generatePieChartView()

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ClassifyBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ClassifyBottomSheetDialogFragment.kt
@@ -6,8 +6,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
+import com.absinthe.libchecker.base.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.database.entity.LCItem
-import com.absinthe.libchecker.ui.fragment.BaseBottomSheetViewDialogFragment
 import com.absinthe.libchecker.utils.extensions.dp
 import com.absinthe.libchecker.view.app.BottomSheetHeaderView
 import com.absinthe.libchecker.view.statistics.ClassifyDialogView

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/LibReferenceFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/LibReferenceFragment.kt
@@ -59,16 +59,13 @@ const val VF_LOADING = 0
 const val VF_LIST = 1
 
 class LibReferenceFragment :
-  BaseListControllerFragment<FragmentLibReferenceBinding>(R.layout.fragment_lib_reference),
+  BaseListControllerFragment<FragmentLibReferenceBinding>(),
   SearchView.OnQueryTextListener {
 
   private val adapter = LibReferenceAdapter()
   private var popup: PopupMenu? = null
   private var category = GlobalValues.currentLibRefType
   private lateinit var layoutManager: LinearLayoutManager
-
-  override fun initBinding(view: View): FragmentLibReferenceBinding =
-    FragmentLibReferenceBinding.bind(view)
 
   override fun init() {
     setHasOptionsMenu(true)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/LibReferenceFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/LibReferenceFragment.kt
@@ -321,7 +321,7 @@ class LibReferenceFragment :
     }
     if (child == VF_LOADING) {
       binding.loading.resumeAnimation()
-      (requireActivity() as BaseActivity).appBar?.setRaised(false)
+      (requireActivity() as BaseActivity<*>).appBar?.setRaised(false)
     } else {
       binding.loading.pauseAnimation()
       binding.list.scrollToPosition(0)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/LibReferenceFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/LibReferenceFragment.kt
@@ -13,7 +13,6 @@ import androidx.appcompat.widget.SearchView
 import androidx.core.view.get
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.BuildConfig
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.ACTIVITY
@@ -29,6 +28,7 @@ import com.absinthe.libchecker.annotation.SERVICE
 import com.absinthe.libchecker.annotation.SPRING
 import com.absinthe.libchecker.annotation.SUMMER
 import com.absinthe.libchecker.annotation.WINTER
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.database.AppItemRepository

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/ChartActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/ChartActivity.kt
@@ -3,8 +3,8 @@ package com.absinthe.libchecker.ui.main
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.ViewGroup
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.databinding.ActivityChartBinding
 import com.absinthe.libchecker.ui.fragment.statistics.ChartFragment
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/ChartActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/ChartActivity.kt
@@ -8,13 +8,7 @@ import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.databinding.ActivityChartBinding
 import com.absinthe.libchecker.ui.fragment.statistics.ChartFragment
 
-class ChartActivity : BaseActivity() {
-  private lateinit var binding: ActivityChartBinding
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivityChartBinding.inflate(layoutInflater)
-    return binding.root
-  }
+class ChartActivity : BaseActivity<ActivityChartBinding>() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
@@ -38,7 +38,7 @@ const val EXTRA_REF_TYPE = "REF_TYPE"
 class LibReferenceActivity : BaseActivity<ActivityLibReferenceBinding>() {
 
   private val adapter by unsafeLazy { AppAdapter(lifecycleScope) }
-  private val viewModel by viewModels<LibReferenceViewModel>()
+  private val viewModel: LibReferenceViewModel by viewModels()
   private val refName by lazy { intent.extras?.getString(EXTRA_REF_NAME) }
   private val refType by lazy { intent.extras?.getInt(EXTRA_REF_TYPE) ?: NATIVE }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
@@ -35,18 +35,12 @@ import rikka.widget.borderview.BorderView
 const val EXTRA_REF_NAME = "REF_NAME"
 const val EXTRA_REF_TYPE = "REF_TYPE"
 
-class LibReferenceActivity : BaseActivity() {
+class LibReferenceActivity : BaseActivity<ActivityLibReferenceBinding>() {
 
-  private lateinit var binding: ActivityLibReferenceBinding
   private val adapter by unsafeLazy { AppAdapter(lifecycleScope) }
   private val viewModel by viewModels<LibReferenceViewModel>()
   private val refName by lazy { intent.extras?.getString(EXTRA_REF_NAME) }
   private val refType by lazy { intent.extras?.getInt(EXTRA_REF_TYPE) ?: NATIVE }
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivityLibReferenceBinding.inflate(layoutInflater)
-    return binding.root
-  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/LibReferenceActivity.kt
@@ -8,13 +8,13 @@ import android.view.ViewGroup
 import androidx.activity.viewModels
 import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.AUTUMN
 import com.absinthe.libchecker.annotation.NATIVE
 import com.absinthe.libchecker.annotation.SPRING
 import com.absinthe.libchecker.annotation.SUMMER
 import com.absinthe.libchecker.annotation.WINTER
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.bean.DetailExtraBean
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.databinding.ActivityLibReferenceBinding

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
@@ -38,16 +38,10 @@ import java.io.File
 
 const val PAGE_TRANSFORM_DURATION = 300L
 
-class MainActivity : BaseActivity() {
+class MainActivity : BaseActivity<ActivityMainBinding>() {
 
-  private lateinit var binding: ActivityMainBinding
   private var clickBottomItemFlag = false
   private val appViewModel by viewModels<HomeViewModel>()
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivityMainBinding.inflate(layoutInflater)
-    return binding.root
-  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
@@ -11,9 +11,9 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.app.Global
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.constant.OnceTag

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
@@ -41,7 +41,7 @@ const val PAGE_TRANSFORM_DURATION = 300L
 class MainActivity : BaseActivity<ActivityMainBinding>() {
 
   private var clickBottomItemFlag = false
-  private val appViewModel by viewModels<HomeViewModel>()
+  private val appViewModel: HomeViewModel by viewModels()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.withContext
 
 class AlbumActivity : BaseActivity<ActivityAlbumBinding>() {
 
-  private val viewModel by viewModels<SnapshotViewModel>()
+  private val viewModel: SnapshotViewModel by viewModels()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
@@ -23,15 +23,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class AlbumActivity : BaseActivity() {
+class AlbumActivity : BaseActivity<ActivityAlbumBinding>() {
 
-  private lateinit var binding: ActivityAlbumBinding
   private val viewModel by viewModels<SnapshotViewModel>()
-
-  override fun setViewBinding(): ViewGroup {
-    binding = ActivityAlbumBinding.inflate(layoutInflater)
-    return binding.root
-  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
@@ -8,8 +8,8 @@ import android.view.MenuItem
 import android.view.ViewGroup
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.absinthe.libchecker.BaseActivity
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.databinding.ActivityAlbumBinding
 import com.absinthe.libchecker.ui.album.BackupActivity

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/CompatExtensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/CompatExtensions.kt
@@ -1,8 +1,12 @@
 package com.absinthe.libchecker.utils.extensions
 
 import android.annotation.SuppressLint
+import android.view.LayoutInflater
 import androidx.appcompat.widget.TintTypedArray
+import androidx.lifecycle.LifecycleOwner
+import androidx.viewbinding.ViewBinding
 import java.io.Closeable
+import java.lang.reflect.ParameterizedType
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -10,6 +14,15 @@ import kotlin.comparisons.reversed as kotlinReversed
 import kotlin.io.use as kotlinUse
 
 fun <T> unsafeLazy(initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)
+
+@Suppress("UNCHECKED_CAST")
+fun <T : ViewBinding> LifecycleOwner.inflateBinding(inflater: LayoutInflater): T {
+  return (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments
+    .filterIsInstance<Class<T>>()
+    .first()
+    .getDeclaredMethod("inflate", LayoutInflater::class.java)
+    .invoke(null, inflater) as T
+}
 
 /**
  * [issue](https://youtrack.jetbrains.com/issue/KT-35216)


### PR DESCRIPTION
- BaseActivity & BaseFragment 等类移入 base 包
- BaseActivity 重构，`binding` 的初始化采用反射，避免子类中的样板代码
- BaseFragment 重构，`binding` 的初始化采用反射，避免子类中的样板代码