### PR TITLE
Replace `ContextCompat.getColor` & `ContextCompat.getDrawable` with extension function

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/AppAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/AppAdapter.kt
@@ -5,7 +5,6 @@ import android.text.SpannableString
 import android.text.style.ImageSpan
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.constant.Constants
@@ -13,6 +12,7 @@ import com.absinthe.libchecker.database.entity.LCItem
 import com.absinthe.libchecker.utils.AppIconCache
 import com.absinthe.libchecker.utils.PackageUtils
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
+import com.absinthe.libchecker.utils.extensions.getDrawable
 import com.absinthe.libchecker.utils.extensions.tintHighlightText
 import com.absinthe.libchecker.view.applist.AppItemView
 import com.absinthe.libchecker.view.detail.CenterAlignImageSpan
@@ -77,7 +77,7 @@ class AppAdapter(val lifecycleScope: LifecycleCoroutineScope) :
 
       if (item.abi.toInt() != Constants.OVERLAY && item.abi.toInt() != Constants.ERROR && abiBadgeRes != 0) {
         spanString = SpannableString("  $str")
-        ContextCompat.getDrawable(context, abiBadgeRes)?.let {
+        abiBadgeRes.getDrawable(context)?.let {
           it.setBounds(0, 0, it.intrinsicWidth, it.intrinsicHeight)
           val span = CenterAlignImageSpan(it)
           spanString.setSpan(span, 0, 1, ImageSpan.ALIGN_BOTTOM)

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/LibStringAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/LibStringAdapter.kt
@@ -12,7 +12,6 @@ import android.text.Spanned
 import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.LibType
 import com.absinthe.libchecker.annotation.NATIVE
@@ -21,6 +20,7 @@ import com.absinthe.libchecker.bean.DISABLED
 import com.absinthe.libchecker.bean.LibStringItemChip
 import com.absinthe.libchecker.utils.LCAppUtils
 import com.absinthe.libchecker.utils.PackageUtils
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.view.detail.ComponentLibItemView
 import com.absinthe.libchecker.view.detail.NativeLibItemView
 import com.absinthe.libchecker.view.detail.StaticLibItemView
@@ -121,7 +121,7 @@ class LibStringAdapter(@LibType val type: Int) :
       val drawable = TransitionDrawable(
         listOf(
           ColorDrawable(Color.TRANSPARENT),
-          ColorDrawable(ContextCompat.getColor(context, R.color.highlightComponent))
+          ColorDrawable(R.color.highlightComponent.getColor(context))
         ).toTypedArray()
       )
       holder.itemView.background = drawable

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/SnapshotAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/SnapshotAdapter.kt
@@ -2,7 +2,6 @@ package com.absinthe.libchecker.recyclerview.adapter.snapshot
 
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
-import android.content.res.ColorStateList
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
@@ -18,6 +17,8 @@ import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.utils.AppIconCache
 import com.absinthe.libchecker.utils.PackageUtils
 import com.absinthe.libchecker.utils.extensions.dp
+import com.absinthe.libchecker.utils.extensions.getColor
+import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.view.detail.CenterAlignImageSpan
 import com.absinthe.libchecker.view.snapshot.SnapshotItemView
 import com.chad.library.adapter.base.BaseQuickAdapter
@@ -57,7 +58,7 @@ class SnapshotAdapter(val lifecycleScope: LifecycleCoroutineScope) :
             AppIconCache.loadIconBitmapAsync(context, ai, ai.uid / 100000, icon)
         } catch (e: PackageManager.NameNotFoundException) {
           val bitmap = ContextCompat.getDrawable(context, R.drawable.ic_app_list)?.apply {
-            setTint(ContextCompat.getColor(context, R.color.textNormal))
+            setTint(R.color.textNormal.getColor(context))
           }?.toBitmap(40.dp, 40.dp)
           icon.post { icon.setImageBitmap(bitmap) }
         }
@@ -73,45 +74,24 @@ class SnapshotAdapter(val lifecycleScope: LifecycleCoroutineScope) :
 
       when {
         item.deleted -> {
-          holder.itemView.backgroundTintList =
-            ColorStateList.valueOf(
-              ContextCompat.getColor(context, R.color.material_red_300)
-            )
-          versionInfo.setTextColor(ContextCompat.getColor(context, R.color.textNormal))
-          targetApiInfo.setTextColor(ContextCompat.getColor(context, R.color.textNormal))
-          abiInfo.setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+          holder.itemView.backgroundTintList = R.color.material_red_300.toColorStateList(context)
+          versionInfo.setTextColor(R.color.textNormal.getColor(context))
+          targetApiInfo.setTextColor(R.color.textNormal.getColor(context))
+          abiInfo.setTextColor(R.color.textNormal.getColor(context))
           isNewOrDeleted = true
         }
         item.newInstalled -> {
-          holder.itemView.backgroundTintList =
-            ColorStateList.valueOf(
-              ContextCompat.getColor(context, R.color.material_green_300)
-            )
-          versionInfo.setTextColor(ContextCompat.getColor(context, R.color.textNormal))
-          targetApiInfo.setTextColor(ContextCompat.getColor(context, R.color.textNormal))
-          abiInfo.setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+          holder.itemView.backgroundTintList = R.color.material_green_300.toColorStateList(context)
+          versionInfo.setTextColor(R.color.textNormal.getColor(context))
+          targetApiInfo.setTextColor(R.color.textNormal.getColor(context))
+          abiInfo.setTextColor(R.color.textNormal.getColor(context))
           isNewOrDeleted = true
         }
         else -> {
           holder.itemView.backgroundTintList = null
-          versionInfo.setTextColor(
-            ContextCompat.getColor(
-              context,
-              android.R.color.darker_gray
-            )
-          )
-          targetApiInfo.setTextColor(
-            ContextCompat.getColor(
-              context,
-              android.R.color.darker_gray
-            )
-          )
-          abiInfo.setTextColor(
-            ContextCompat.getColor(
-              context,
-              android.R.color.darker_gray
-            )
-          )
+          versionInfo.setTextColor(android.R.color.darker_gray.getColor(context))
+          targetApiInfo.setTextColor(android.R.color.darker_gray.getColor(context))
+          abiInfo.setTextColor(android.R.color.darker_gray.getColor(context))
         }
       }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/SnapshotAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/SnapshotAdapter.kt
@@ -18,6 +18,7 @@ import com.absinthe.libchecker.utils.AppIconCache
 import com.absinthe.libchecker.utils.PackageUtils
 import com.absinthe.libchecker.utils.extensions.dp
 import com.absinthe.libchecker.utils.extensions.getColor
+import com.absinthe.libchecker.utils.extensions.getDrawable
 import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.view.detail.CenterAlignImageSpan
 import com.absinthe.libchecker.view.snapshot.SnapshotItemView
@@ -121,7 +122,7 @@ class SnapshotAdapter(val lifecycleScope: LifecycleCoroutineScope) :
       var abiBadgeRes = PackageUtils.getAbiBadgeResource(item.abiDiff.old.toInt())
       if (item.abiDiff.old.toInt() != Constants.ERROR && item.abiDiff.old.toInt() != Constants.OVERLAY && abiBadgeRes != 0) {
         oldAbiSpanString = SpannableString("  $oldAbiString")
-        ContextCompat.getDrawable(context, abiBadgeRes)?.let {
+        abiBadgeRes.getDrawable(context)?.let {
           it.setBounds(0, 0, it.intrinsicWidth, it.intrinsicHeight)
           val span = CenterAlignImageSpan(it)
           oldAbiSpanString.setSpan(span, 0, 1, ImageSpan.ALIGN_BOTTOM)
@@ -138,7 +139,7 @@ class SnapshotAdapter(val lifecycleScope: LifecycleCoroutineScope) :
         abiBadgeRes = PackageUtils.getAbiBadgeResource(item.abiDiff.new.toInt())
         if (item.abiDiff.new.toInt() != Constants.ERROR && item.abiDiff.new.toInt() != Constants.OVERLAY && abiBadgeRes != 0) {
           newAbiSpanString = SpannableString("  $newAbiString")
-          ContextCompat.getDrawable(context, abiBadgeRes)?.let {
+          abiBadgeRes.getDrawable(context)?.let {
             it.setBounds(0, 0, it.intrinsicWidth, it.intrinsicHeight)
             val span = CenterAlignImageSpan(it)
             newAbiSpanString.setSpan(span, 0, 1, ImageSpan.ALIGN_BOTTOM)

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/SnapshotDetailCountAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/SnapshotDetailCountAdapter.kt
@@ -1,15 +1,14 @@
 package com.absinthe.libchecker.recyclerview.adapter.snapshot
 
-import android.content.res.ColorStateList
 import android.graphics.Color
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.bean.ADDED
 import com.absinthe.libchecker.bean.CHANGED
 import com.absinthe.libchecker.bean.MOVED
 import com.absinthe.libchecker.bean.REMOVED
 import com.absinthe.libchecker.recyclerview.adapter.snapshot.node.SnapshotDetailCountNode
+import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.view.snapshot.SnapshotDetailCountView
 import com.chad.library.adapter.base.BaseQuickAdapter
 import com.chad.library.adapter.base.viewholder.BaseViewHolder
@@ -37,7 +36,7 @@ class SnapshotDetailCountAdapter : BaseQuickAdapter<SnapshotDetailCountNode, Bas
 
     (holder.itemView as SnapshotDetailCountView).apply {
       text = item.count.toString()
-      backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
+      backgroundTintList = colorRes.toColorStateList(context)
     }
   }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/SnapshotDetailCountAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/SnapshotDetailCountAdapter.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.recyclerview.adapter.snapshot
 
-import android.graphics.Color
 import android.view.ViewGroup
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.bean.ADDED

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
@@ -1,10 +1,8 @@
 package com.absinthe.libchecker.recyclerview.adapter.snapshot.provider
 
-import android.content.res.ColorStateList
 import android.graphics.Color
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.base.BaseActivity
@@ -15,6 +13,7 @@ import com.absinthe.libchecker.bean.REMOVED
 import com.absinthe.libchecker.recyclerview.adapter.snapshot.node.SnapshotComponentNode
 import com.absinthe.libchecker.ui.fragment.detail.LibDetailDialogFragment
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.view.snapshot.SnapshotDetailComponentView
 import com.chad.library.adapter.base.entity.node.BaseNode
 import com.chad.library.adapter.base.provider.BaseNodeProvider
@@ -58,8 +57,7 @@ class SnapshotComponentProvider(val lifecycleScope: LifecycleCoroutineScope) : B
         }
       )
 
-      helper.itemView.backgroundTintList =
-        ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
+      helper.itemView.backgroundTintList = colorRes.toColorStateList(context)
 
       lifecycleScope.launch {
         val rule = LCAppUtils.getRuleWithRegex(snapshotItem.name, snapshotItem.itemType)

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotComponentProvider.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.recyclerview.adapter.snapshot.provider
 
-import android.graphics.Color
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.lifecycle.LifecycleCoroutineScope
@@ -66,8 +65,7 @@ class SnapshotComponentProvider(val lifecycleScope: LifecycleCoroutineScope) : B
         if (rule != null) {
           setChipOnClickListener {
             val name = item.item.name
-            val regexName =
-              LCAppUtils.findRuleRegex(name, item.item.itemType)?.regexName
+            val regexName = LCAppUtils.findRuleRegex(name, item.item.itemType)?.regexName
             LibDetailDialogFragment.newInstance(name, item.item.itemType, regexName)
               .apply {
                 show(

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
@@ -1,6 +1,5 @@
 package com.absinthe.libchecker.recyclerview.adapter.snapshot.provider
 
-import android.graphics.Color
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.lifecycle.LifecycleCoroutineScope
@@ -65,8 +64,7 @@ class SnapshotNativeProvider(val lifecycleScope: LifecycleCoroutineScope) : Base
         if (rule != null) {
           setChipOnClickListener {
             val name = item.item.name
-            val regexName =
-              LCAppUtils.findRuleRegex(name, item.item.itemType)?.regexName
+            val regexName = LCAppUtils.findRuleRegex(name, item.item.itemType)?.regexName
             LibDetailDialogFragment.newInstance(name, item.item.itemType, regexName)
               .apply {
                 show(

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/snapshot/provider/SnapshotNativeProvider.kt
@@ -1,10 +1,8 @@
 package com.absinthe.libchecker.recyclerview.adapter.snapshot.provider
 
-import android.content.res.ColorStateList
 import android.graphics.Color
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.NATIVE
@@ -15,6 +13,7 @@ import com.absinthe.libchecker.bean.REMOVED
 import com.absinthe.libchecker.recyclerview.adapter.snapshot.node.SnapshotNativeNode
 import com.absinthe.libchecker.ui.fragment.detail.LibDetailDialogFragment
 import com.absinthe.libchecker.utils.LCAppUtils
+import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.view.snapshot.SnapshotDetailNativeView
 import com.chad.library.adapter.base.entity.node.BaseNode
 import com.chad.library.adapter.base.provider.BaseNodeProvider
@@ -57,8 +56,7 @@ class SnapshotNativeProvider(val lifecycleScope: LifecycleCoroutineScope) : Base
         }
       )
 
-      helper.itemView.backgroundTintList =
-        ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
+      helper.itemView.backgroundTintList = colorRes.toColorStateList(context)
 
       lifecycleScope.launch {
         val rule = LCAppUtils.getRuleWithRegex(snapshotItem.name, NATIVE)

--- a/app/src/main/kotlin/com/absinthe/libchecker/services/ShootService.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/services/ShootService.kt
@@ -12,7 +12,6 @@ import android.os.RemoteCallbackList
 import android.os.RemoteException
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.absinthe.libchecker.R
@@ -28,6 +27,7 @@ import com.absinthe.libchecker.database.entity.TimeStampItem
 import com.absinthe.libchecker.ui.main.MainActivity
 import com.absinthe.libchecker.utils.LCAppUtils
 import com.absinthe.libchecker.utils.PackageUtils
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.viewmodel.GET_INSTALL_APPS_RETRY_PERIOD
 import com.absinthe.libraries.utils.manager.TimeRecorder
 import com.google.gson.Gson
@@ -312,7 +312,7 @@ class ShootService : LifecycleService() {
     builder.setContentTitle(createConfigurationContext(configuration).resources.getString(R.string.noti_shoot_title))
       .setSmallIcon(R.drawable.ic_logo)
       .setLargeIcon(BitmapFactory.decodeResource(resources, R.mipmap.ic_launcher))
-      .setColor(ContextCompat.getColor(this, R.color.colorPrimary))
+      .setColor(R.color.colorPrimary.getColor(this))
       .setPriority(NotificationCompat.PRIORITY_LOW)
       .setContentIntent(pi)
       .setProgress(0, 0, true)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/about/AboutActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/about/AboutActivity.kt
@@ -15,7 +15,6 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.StringRes
-import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.text.HtmlCompat
 import androidx.lifecycle.lifecycleScope
@@ -26,6 +25,7 @@ import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.constant.URLManager
 import com.absinthe.libchecker.utils.PackageUtils
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.showLongToast
 import com.absinthe.libraries.me.Absinthe
 import com.absinthe.libraries.utils.utils.UiUtils
@@ -114,19 +114,12 @@ class AboutActivity : AbsAboutActivity() {
           val drawable = TransitionDrawable(
             arrayOf(
               headerContentLayout.background,
-              ColorDrawable(ContextCompat.getColor(this, R.color.renge))
+              ColorDrawable(R.color.renge.getColor(this))
             )
           )
           setHeaderBackground(drawable)
-          setHeaderContentScrim(
-            ColorDrawable(
-              ContextCompat.getColor(
-                this,
-                R.color.renge
-              )
-            )
-          )
-          window.statusBarColor = ContextCompat.getColor(this, R.color.renge)
+          setHeaderContentScrim(ColorDrawable(R.color.renge.getColor(this)))
+          window.statusBarColor = R.color.renge.getColor(this)
           drawable.startTransition(250)
 
           val fd = assets.openFd("renge_no_koe.aac")

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
@@ -11,7 +11,6 @@ import android.text.style.ImageSpan
 import android.text.style.StrikethroughSpan
 import android.view.MenuItem
 import androidx.activity.viewModels
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -36,6 +35,7 @@ import com.absinthe.libchecker.ui.fragment.detail.impl.NativeAnalysisFragment
 import com.absinthe.libchecker.ui.fragment.detail.impl.StaticAnalysisFragment
 import com.absinthe.libchecker.utils.FileUtils
 import com.absinthe.libchecker.utils.PackageUtils
+import com.absinthe.libchecker.utils.extensions.getDrawable
 import com.absinthe.libchecker.utils.extensions.isOrientationPortrait
 import com.absinthe.libchecker.utils.extensions.setLongClickCopiedToClipboard
 import com.absinthe.libchecker.utils.manifest.ManifestReader
@@ -176,24 +176,22 @@ class ApkDetailActivity : BaseActivity<ActivityAppDetailBinding>(), IDetailConta
                 ).let { str ->
                   spanString = SpannableString("  $str")
                 }
-                ContextCompat.getDrawable(
-                  this@ApkDetailActivity,
-                  PackageUtils.getAbiBadgeResource(eachAbi)
-                )?.mutate()?.let { drawable ->
-                  drawable.setBounds(
-                    0,
-                    0,
-                    drawable.intrinsicWidth,
-                    drawable.intrinsicHeight
-                  )
-                  if (eachAbi != abi % Constants.MULTI_ARCH) {
-                    drawable.alpha = 128
-                  } else {
-                    drawable.alpha = 255
+                PackageUtils.getAbiBadgeResource(eachAbi).getDrawable(this@ApkDetailActivity)
+                  ?.mutate()?.let { drawable ->
+                    drawable.setBounds(
+                      0,
+                      0,
+                      drawable.intrinsicWidth,
+                      drawable.intrinsicHeight
+                    )
+                    if (eachAbi != abi % Constants.MULTI_ARCH) {
+                      drawable.alpha = 128
+                    } else {
+                      drawable.alpha = 255
+                    }
+                    val span = CenterAlignImageSpan(drawable)
+                    spanString.setSpan(span, 0, 1, ImageSpan.ALIGN_BOTTOM)
                   }
-                  val span = CenterAlignImageSpan(drawable)
-                  spanString.setSpan(span, 0, 1, ImageSpan.ALIGN_BOTTOM)
-                }
                 if (eachAbi != abi % Constants.MULTI_ARCH) {
                   spanString.setSpan(
                     StrikethroughSpan(),

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/AppDetailActivity.kt
@@ -15,7 +15,6 @@ import android.text.style.StrikethroughSpan
 import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
-import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -50,6 +49,7 @@ import com.absinthe.libchecker.ui.fragment.detail.impl.StaticAnalysisFragment
 import com.absinthe.libchecker.ui.main.EXTRA_REF_NAME
 import com.absinthe.libchecker.ui.main.EXTRA_REF_TYPE
 import com.absinthe.libchecker.utils.PackageUtils
+import com.absinthe.libchecker.utils.extensions.getDrawable
 import com.absinthe.libchecker.utils.extensions.isOrientationPortrait
 import com.absinthe.libchecker.utils.extensions.setLongClickCopiedToClipboard
 import com.absinthe.libchecker.utils.extensions.unsafeLazy
@@ -68,7 +68,9 @@ import java.io.File
 const val EXTRA_PACKAGE_NAME = "android.intent.extra.PACKAGE_NAME"
 const val EXTRA_DETAIL_BEAN = "EXTRA_DETAIL_BEAN"
 
-class AppDetailActivity : CheckPackageOnResumingActivity<ActivityAppDetailBinding>(), IDetailContainer {
+class AppDetailActivity :
+  CheckPackageOnResumingActivity<ActivityAppDetailBinding>(),
+  IDetailContainer {
 
   private val pkgName by unsafeLazy { intent.getStringExtra(EXTRA_PACKAGE_NAME) }
   private val refName by unsafeLazy { intent.getStringExtra(EXTRA_REF_NAME) }
@@ -195,24 +197,22 @@ class AppDetailActivity : CheckPackageOnResumingActivity<ActivityAppDetailBindin
               ).let { str ->
                 spanString = SpannableString("  $str")
               }
-              ContextCompat.getDrawable(
-                this@AppDetailActivity,
-                PackageUtils.getAbiBadgeResource(it)
-              )?.mutate()?.let { drawable ->
-                drawable.setBounds(
-                  0,
-                  0,
-                  drawable.intrinsicWidth,
-                  drawable.intrinsicHeight
-                )
-                if (it != abi % Constants.MULTI_ARCH) {
-                  drawable.alpha = 128
-                } else {
-                  drawable.alpha = 255
+              PackageUtils.getAbiBadgeResource(it)
+                .getDrawable(this@AppDetailActivity)?.mutate()?.let { drawable ->
+                  drawable.setBounds(
+                    0,
+                    0,
+                    drawable.intrinsicWidth,
+                    drawable.intrinsicHeight
+                  )
+                  if (it != abi % Constants.MULTI_ARCH) {
+                    drawable.alpha = 128
+                  } else {
+                    drawable.alpha = 255
+                  }
+                  val span = CenterAlignImageSpan(drawable)
+                  spanString.setSpan(span, 0, 1, ImageSpan.ALIGN_BOTTOM)
                 }
-                val span = CenterAlignImageSpan(drawable)
-                spanString.setSpan(span, 0, 1, ImageSpan.ALIGN_BOTTOM)
-              }
               if (it != abi % Constants.MULTI_ARCH) {
                 spanString.setSpan(
                   StrikethroughSpan(),

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/SnapshotDetailActivity.kt
@@ -13,7 +13,12 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.SimpleItemAnimator
 import coil.load
 import com.absinthe.libchecker.R
-import com.absinthe.libchecker.annotation.*
+import com.absinthe.libchecker.annotation.ACTIVITY
+import com.absinthe.libchecker.annotation.NATIVE
+import com.absinthe.libchecker.annotation.PERMISSION
+import com.absinthe.libchecker.annotation.PROVIDER
+import com.absinthe.libchecker.annotation.RECEIVER
+import com.absinthe.libchecker.annotation.SERVICE
 import com.absinthe.libchecker.base.BaseActivity
 import com.absinthe.libchecker.bean.DetailExtraBean
 import com.absinthe.libchecker.bean.REMOVED
@@ -114,8 +119,7 @@ class SnapshotDetailActivity : BaseActivity<ActivitySnapshotDetailBinding>() {
         load(icon)
         setOnClickListener {
           lifecycleScope.launch {
-            val lcItem =
-              Repositories.lcRepository.getItem(entity.packageName) ?: return@launch
+            val lcItem = Repositories.lcRepository.getItem(entity.packageName) ?: return@launch
             startActivity(
               Intent(this@SnapshotDetailActivity, AppDetailActivity::class.java)
                 .putExtras(

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
@@ -7,7 +7,6 @@ import android.os.Build
 import android.view.HapticFeedbackConstants
 import android.view.ViewGroup
 import android.widget.LinearLayout
-import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import com.absinthe.libchecker.R
@@ -20,6 +19,7 @@ import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.database.entity.LCItem
 import com.absinthe.libchecker.databinding.FragmentPieChartBinding
 import com.absinthe.libchecker.utils.PackageUtils
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.isShowing
 import com.absinthe.libchecker.view.statistics.IntegerFormatter
 import com.absinthe.libchecker.view.statistics.OsVersionAxisFormatter
@@ -144,12 +144,12 @@ class ChartFragment :
       val data = PieData(dataSet).apply {
         setValueFormatter(PercentFormatter(chartView as PieChart))
         setValueTextSize(10f)
-        setValueTextColor(ContextCompat.getColor(requireContext(), R.color.textNormal))
+        setValueTextColor(R.color.textNormal.getColor(requireContext()))
       }
 
       (chartView as PieChart).apply {
         this.data = data
-        setEntryLabelColor(ContextCompat.getColor(requireContext(), R.color.textNormal))
+        setEntryLabelColor(R.color.textNormal.getColor(requireContext()))
         highlightValues(null)
         invalidate()
       }
@@ -287,7 +287,7 @@ class ChartFragment :
       // dataSet.setSelectionShift(0f);
       val data = BarData(dataSet).apply {
         setValueTextSize(10f)
-        setValueTextColor(ContextCompat.getColor(requireContext(), R.color.textNormal))
+        setValueTextColor(R.color.textNormal.getColor(requireContext()))
       }
 
       (chartView as HorizontalBarChart).apply {
@@ -433,18 +433,17 @@ class ChartFragment :
         verticalAlignment = Legend.LegendVerticalAlignment.BOTTOM
         horizontalAlignment = Legend.LegendHorizontalAlignment.LEFT
         orientation = Legend.LegendOrientation.HORIZONTAL
-        textColor =
-          ContextCompat.getColor(this@ChartFragment.requireContext(), R.color.textNormal)
+        textColor = R.color.textNormal.getColor(requireContext())
         xEntrySpace = 7f
         yEntrySpace = 0f
         isWordWrapEnabled = true
       }
       setUsePercentValues(true)
       setExtraOffsets(24f, 0f, 24f, 0f)
-      setEntryLabelColor(ContextCompat.getColor(context, R.color.textNormal))
+      setEntryLabelColor(R.color.textNormal.getColor(requireContext()))
       setEntryLabelTextSize(11f)
       setNoDataText(getString(R.string.loading))
-      setNoDataTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setNoDataTextColor(R.color.textNormal.getColor(requireContext()))
       setOnChartValueSelectedListener(this@ChartFragment)
       setHoleColor(Color.TRANSPARENT)
     }
@@ -469,19 +468,19 @@ class ChartFragment :
         setLabelCount(existApiList.size, false)
         granularity = 1f
         textSize = 10f
-        textColor = ContextCompat.getColor(requireContext(), R.color.textNormal)
+        textColor = R.color.textNormal.getColor(requireContext())
       }
       axisLeft.apply {
         valueFormatter = IntegerFormatter()
         setDrawGridLines(false)
         setDrawZeroLine(false)
-        textColor = ContextCompat.getColor(requireContext(), R.color.textNormal)
+        textColor = R.color.textNormal.getColor(requireContext())
       }
       axisRight.apply {
         valueFormatter = IntegerFormatter()
         setDrawGridLines(false)
         setDrawZeroLine(false)
-        textColor = ContextCompat.getColor(requireContext(), R.color.textNormal)
+        textColor = R.color.textNormal.getColor(requireContext())
       }
       setMaxVisibleValueCount(Build.VERSION_CODES.R + 1)
       setDrawGridBackground(false)
@@ -489,7 +488,7 @@ class ChartFragment :
       setDrawMarkers(false)
       setExtraOffsets(12f, 0f, 24f, 0f)
       setNoDataText(getString(R.string.loading))
-      setNoDataTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setNoDataTextColor(R.color.textNormal.getColor(context))
       setOnChartValueSelectedListener(this@ChartFragment)
     }
   }

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/CompatExtensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/CompatExtensions.kt
@@ -1,8 +1,13 @@
 package com.absinthe.libchecker.utils.extensions
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.res.ColorStateList
 import android.view.LayoutInflater
+import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
 import androidx.appcompat.widget.TintTypedArray
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.viewbinding.ViewBinding
 import java.io.Closeable
@@ -14,6 +19,13 @@ import kotlin.comparisons.reversed as kotlinReversed
 import kotlin.io.use as kotlinUse
 
 fun <T> unsafeLazy(initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)
+
+@ColorInt
+fun @receiver:ColorRes Int.getColor(context: Context): Int = ContextCompat.getColor(context, this)
+
+fun @receiver:ColorRes Int.toColorStateList(context: Context): ColorStateList {
+  return ColorStateList.valueOf(getColor(context))
+}
 
 @Suppress("UNCHECKED_CAST")
 fun <T : ViewBinding> LifecycleOwner.inflateBinding(inflater: LayoutInflater): T {

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/CompatExtensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/CompatExtensions.kt
@@ -3,9 +3,11 @@ package com.absinthe.libchecker.utils.extensions
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
+import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.TintTypedArray
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
@@ -22,6 +24,9 @@ fun <T> unsafeLazy(initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NO
 
 @ColorInt
 fun @receiver:ColorRes Int.getColor(context: Context): Int = ContextCompat.getColor(context, this)
+
+fun @receiver:DrawableRes Int.getDrawable(context: Context): Drawable? =
+  ContextCompat.getDrawable(context, this)
 
 fun @receiver:ColorRes Int.toColorStateList(context: Context): ColorStateList {
   return ColorStateList.valueOf(getColor(context))

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/ViewExtensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/ViewExtensions.kt
@@ -12,7 +12,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.TextView
-import androidx.core.content.ContextCompat
 import androidx.viewpager2.widget.ViewPager2
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.utils.showToast
@@ -86,7 +85,7 @@ fun TextView.tintHighlightText(highlightText: String, rawText: String) {
     val spannableString = SpannableString(text.toString())
     val start = text.indexOf(highlightText, 0, true)
     spannableString.setSpan(
-      ForegroundColorSpan(ContextCompat.getColor(context, R.color.colorPrimary)),
+      ForegroundColorSpan(R.color.colorPrimary.getColor(context)),
       start, start + highlightText.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE
     )
     builder.append(spannableString)

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/applist/AppItemView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/applist/AppItemView.kt
@@ -8,9 +8,9 @@ import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import androidx.core.view.marginStart
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.card.MaterialCardView
@@ -46,7 +46,7 @@ class AppItemView(context: Context) : MaterialCardView(context) {
       ).also {
         it.marginStart = 8.dp
       }
-      setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setTextColor(R.color.textNormal.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
       maxLines = 1
       ellipsize = TextUtils.TruncateAt.END
@@ -59,7 +59,7 @@ class AppItemView(context: Context) : MaterialCardView(context) {
           ViewGroup.LayoutParams.MATCH_PARENT,
           ViewGroup.LayoutParams.WRAP_CONTENT
         )
-        setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+        setTextColor(R.color.textNormal.getColor(context))
         setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
         maxLines = 1
         ellipsize = TextUtils.TruncateAt.END
@@ -76,7 +76,7 @@ class AppItemView(context: Context) : MaterialCardView(context) {
         ViewGroup.LayoutParams.MATCH_PARENT,
         ViewGroup.LayoutParams.WRAP_CONTENT
       )
-      setTextColor(ContextCompat.getColor(context, android.R.color.darker_gray))
+      setTextColor(android.R.color.darker_gray.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
       maxLines = 1
       ellipsize = TextUtils.TruncateAt.END
@@ -93,7 +93,7 @@ class AppItemView(context: Context) : MaterialCardView(context) {
         ViewGroup.LayoutParams.MATCH_PARENT,
         ViewGroup.LayoutParams.WRAP_CONTENT
       )
-      setTextColor(ContextCompat.getColor(context, android.R.color.darker_gray))
+      setTextColor(android.R.color.darker_gray.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
       maxLines = 1
       ellipsize = TextUtils.TruncateAt.END

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/detail/ComponentLibItemView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/detail/ComponentLibItemView.kt
@@ -1,19 +1,19 @@
 package com.absinthe.libchecker.view.detail
 
 import android.content.Context
-import android.content.res.ColorStateList
 import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.util.TypedValue
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import androidx.core.view.marginEnd
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.bean.LibChip
 import com.absinthe.libchecker.constant.GlobalValues
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
+import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.utils.extensions.valueUnsafe
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.chip.Chip
@@ -37,7 +37,7 @@ class ComponentLibItemView(context: Context) : AViewGroup(context) {
       ).also {
         it.marginEnd = context.getDimensionPixelSize(R.dimen.normal_padding)
       }
-      setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setTextColor(R.color.textNormal.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
       addView(this)
     }
@@ -64,12 +64,7 @@ class ComponentLibItemView(context: Context) : AViewGroup(context) {
 
         if (!GlobalValues.isColorfulIcon.valueUnsafe) {
           if (libChip.iconRes == R.drawable.ic_sdk_placeholder) {
-            chipIconTint = ColorStateList.valueOf(
-              ContextCompat.getColor(
-                context,
-                R.color.textNormal
-              )
-            )
+            chipIconTint = R.color.textNormal.toColorStateList(context)
           } else {
             val icon = chipIcon
             icon?.let {

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/detail/NativeLibItemView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/detail/NativeLibItemView.kt
@@ -1,19 +1,19 @@
 package com.absinthe.libchecker.view.detail
 
 import android.content.Context
-import android.content.res.ColorStateList
 import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.util.TypedValue
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import androidx.core.view.marginEnd
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.bean.LibChip
 import com.absinthe.libchecker.constant.GlobalValues
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
+import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.utils.extensions.valueUnsafe
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.chip.Chip
@@ -37,7 +37,7 @@ class NativeLibItemView(context: Context) : AViewGroup(context) {
       ).also {
         it.marginEnd = context.getDimensionPixelSize(R.dimen.normal_padding)
       }
-      setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setTextColor(R.color.textNormal.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
       addView(this)
     }
@@ -74,12 +74,7 @@ class NativeLibItemView(context: Context) : AViewGroup(context) {
 
         if (!GlobalValues.isColorfulIcon.valueUnsafe) {
           if (libChip.iconRes == R.drawable.ic_sdk_placeholder) {
-            chipIconTint = ColorStateList.valueOf(
-              ContextCompat.getColor(
-                context,
-                R.color.textNormal
-              )
-            )
+            chipIconTint = R.color.textNormal.toColorStateList(context)
           } else {
             val icon = chipIcon
             icon?.let {

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/detail/StaticLibItemView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/detail/StaticLibItemView.kt
@@ -1,18 +1,18 @@
 package com.absinthe.libchecker.view.detail
 
 import android.content.Context
-import android.content.res.ColorStateList
 import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.util.TypedValue
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.bean.LibChip
 import com.absinthe.libchecker.constant.GlobalValues
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
+import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.utils.extensions.valueUnsafe
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.chip.Chip
@@ -34,7 +34,7 @@ class StaticLibItemView(context: Context) : AViewGroup(context) {
         ViewGroup.LayoutParams.WRAP_CONTENT,
         ViewGroup.LayoutParams.WRAP_CONTENT
       )
-      setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setTextColor(R.color.textNormal.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
       addView(this)
     }
@@ -71,12 +71,7 @@ class StaticLibItemView(context: Context) : AViewGroup(context) {
 
         if (!GlobalValues.isColorfulIcon.valueUnsafe) {
           if (libChip.iconRes == R.drawable.ic_sdk_placeholder) {
-            chipIconTint = ColorStateList.valueOf(
-              ContextCompat.getColor(
-                context,
-                R.color.textNormal
-              )
-            )
+            chipIconTint = R.color.textNormal.toColorStateList(context)
           } else {
             val icon = chipIcon
             icon?.let {

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/detail/TextSwitcherView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/detail/TextSwitcherView.kt
@@ -9,8 +9,8 @@ import android.view.View
 import android.widget.TextSwitcher
 import android.widget.TextView
 import android.widget.ViewSwitcher
-import androidx.core.content.ContextCompat
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.utils.extensions.getColor
 
 /**
  * <pre>
@@ -40,7 +40,7 @@ class TextSwitcherView : TextSwitcher, ViewSwitcher.ViewFactory {
       gravity = Gravity.START or Gravity.CENTER
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
       setTypeface(null, Typeface.BOLD)
-      setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setTextColor(R.color.textNormal.getColor(context))
     }
   }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotDetailComponentView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotDetailComponentView.kt
@@ -10,14 +10,15 @@ import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import androidx.core.view.marginStart
 import androidx.core.view.marginTop
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.constant.librarymap.IconResMap
 import com.absinthe.libchecker.database.entity.RuleEntity
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
+import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.utils.extensions.valueUnsafe
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.card.MaterialCardView
@@ -41,12 +42,7 @@ class SnapshotDetailComponentView(context: Context) : MaterialCardView(context) 
 
     val typeIcon = AppCompatImageView(context).apply {
       layoutParams = LayoutParams(16.dp, 16.dp)
-      imageTintList = ColorStateList.valueOf(
-        ContextCompat.getColor(
-          context,
-          R.color.material_blue_grey_700
-        )
-      )
+      imageTintList = ColorStateList.valueOf(R.color.material_blue_grey_700.getColor(context))
       addView(this)
     }
 
@@ -99,8 +95,7 @@ class SnapshotDetailComponentView(context: Context) : MaterialCardView(context) 
         chip!!.apply {
           setChipIconResource(IconResMap.getIconRes(entity.iconIndex))
           text = entity.label
-          chipBackgroundColor =
-            ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
+          chipBackgroundColor = colorRes.toColorStateList(context)
 
           if (!GlobalValues.isColorfulIcon.valueUnsafe && !IconResMap.isSingleColorIcon(
               entity.iconIndex

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotDetailCountView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotDetailCountView.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.utils.extensions.dp
+import com.absinthe.libchecker.utils.extensions.getColor
 
 class SnapshotDetailCountView(context: Context) : AppCompatTextView(context) {
 
@@ -21,6 +22,6 @@ class SnapshotDetailCountView(context: Context) : AppCompatTextView(context) {
     background = ContextCompat.getDrawable(context, R.drawable.bg_snapshot_detail_count)
     setPadding(8.dp, 2.dp, 8.dp, 2.dp)
     setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
-    setTextColor(ContextCompat.getColor(context, R.color.grey_600))
+    setTextColor(R.color.grey_600.getColor(context))
   }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotDetailCountView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotDetailCountView.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import android.util.TypedValue
 import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.utils.extensions.dp
 import com.absinthe.libchecker.utils.extensions.getColor
+import com.absinthe.libchecker.utils.extensions.getDrawable
 
 class SnapshotDetailCountView(context: Context) : AppCompatTextView(context) {
 
@@ -19,7 +19,7 @@ class SnapshotDetailCountView(context: Context) : AppCompatTextView(context) {
       it.marginStart = 4.dp
       it.marginEnd = 4.dp
     }
-    background = ContextCompat.getDrawable(context, R.drawable.bg_snapshot_detail_count)
+    background = R.drawable.bg_snapshot_detail_count.getDrawable(context)
     setPadding(8.dp, 2.dp, 8.dp, 2.dp)
     setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
     setTextColor(R.color.grey_600.getColor(context))

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotDetailNativeView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotDetailNativeView.kt
@@ -10,14 +10,15 @@ import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import androidx.core.view.marginStart
 import androidx.core.view.marginTop
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.constant.librarymap.IconResMap
 import com.absinthe.libchecker.database.entity.RuleEntity
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
+import com.absinthe.libchecker.utils.extensions.toColorStateList
 import com.absinthe.libchecker.utils.extensions.valueUnsafe
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.card.MaterialCardView
@@ -42,10 +43,7 @@ class SnapshotDetailNativeView(context: Context) : MaterialCardView(context) {
     val typeIcon = AppCompatImageView(context).apply {
       layoutParams = LayoutParams(16.dp, 16.dp)
       imageTintList = ColorStateList.valueOf(
-        ContextCompat.getColor(
-          context,
-          R.color.material_blue_grey_700
-        )
+        R.color.material_blue_grey_700.getColor(context)
       )
       addView(this)
     }
@@ -114,8 +112,7 @@ class SnapshotDetailNativeView(context: Context) : MaterialCardView(context) {
         chip!!.apply {
           setChipIconResource(IconResMap.getIconRes(entity.iconIndex))
           text = entity.label
-          chipBackgroundColor =
-            ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
+          chipBackgroundColor = colorRes.toColorStateList(context)
 
           if (!GlobalValues.isColorfulIcon.valueUnsafe && !IconResMap.isSingleColorIcon(
               entity.iconIndex

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotItemView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotItemView.kt
@@ -7,9 +7,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import androidx.core.view.marginStart
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.card.MaterialCardView
@@ -46,7 +46,7 @@ class SnapshotItemView(context: Context) : MaterialCardView(context) {
       ).also {
         it.marginStart = 8.dp
       }
-      setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setTextColor(R.color.textNormal.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 15f)
       addView(this)
     }
@@ -54,10 +54,9 @@ class SnapshotItemView(context: Context) : MaterialCardView(context) {
     val packageName =
       AppCompatTextView(ContextThemeWrapper(context, R.style.TextView_SansSerif)).apply {
         layoutParams = LayoutParams(
-          ViewGroup.LayoutParams.MATCH_PARENT,
-          ViewGroup.LayoutParams.WRAP_CONTENT
+          ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT
         )
-        setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+        setTextColor(R.color.textNormal.getColor(context))
         setTextSize(TypedValue.COMPLEX_UNIT_SP, 13f)
         addView(this)
       }
@@ -72,7 +71,7 @@ class SnapshotItemView(context: Context) : MaterialCardView(context) {
         ViewGroup.LayoutParams.MATCH_PARENT,
         ViewGroup.LayoutParams.WRAP_CONTENT
       )
-      setTextColor(ContextCompat.getColor(context, android.R.color.darker_gray))
+      setTextColor(android.R.color.darker_gray.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 11f)
       addView(this)
     }
@@ -87,7 +86,7 @@ class SnapshotItemView(context: Context) : MaterialCardView(context) {
         ViewGroup.LayoutParams.MATCH_PARENT,
         ViewGroup.LayoutParams.WRAP_CONTENT
       )
-      setTextColor(ContextCompat.getColor(context, android.R.color.darker_gray))
+      setTextColor(android.R.color.darker_gray.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 11f)
       addView(this)
     }
@@ -102,7 +101,7 @@ class SnapshotItemView(context: Context) : MaterialCardView(context) {
         ViewGroup.LayoutParams.MATCH_PARENT,
         ViewGroup.LayoutParams.WRAP_CONTENT
       )
-      setTextColor(ContextCompat.getColor(context, android.R.color.darker_gray))
+      setTextColor(android.R.color.darker_gray.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 11f)
       addView(this)
     }
@@ -121,7 +120,7 @@ class SnapshotItemView(context: Context) : MaterialCardView(context) {
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT
           )
-          setBackgroundColor(ContextCompat.getColor(context, R.color.material_red_300))
+          setBackgroundColor(R.color.material_red_300.getColor(context))
           alpha = 0.5f
           addView(this)
         }

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotStateIndicatorView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/SnapshotStateIndicatorView.kt
@@ -5,8 +5,8 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.view.View
 import androidx.annotation.ColorRes
-import androidx.core.content.ContextCompat
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.utils.extensions.getColor
 
 class SnapshotStateIndicatorView(context: Context) : View(context) {
   var added: Boolean = false
@@ -52,7 +52,7 @@ class SnapshotStateIndicatorView(context: Context) : View(context) {
   }
 
   private fun drawItem(@ColorRes color: Int, canvas: Canvas) {
-    p.color = ContextCompat.getColor(context, color)
+    p.color = color.getColor(context)
     canvas.drawRect(
       0f,
       drawOverPosition,

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/TrackItemView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/snapshot/TrackItemView.kt
@@ -7,9 +7,9 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import androidx.core.view.marginStart
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.card.MaterialCardView
@@ -46,7 +46,7 @@ class TrackItemView(context: Context) : MaterialCardView(context) {
       ).also {
         it.marginStart = 8.dp
       }
-      setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setTextColor(R.color.textNormal.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
       addView(this)
     }
@@ -57,7 +57,7 @@ class TrackItemView(context: Context) : MaterialCardView(context) {
           ViewGroup.LayoutParams.MATCH_PARENT,
           ViewGroup.LayoutParams.WRAP_CONTENT
         )
-        setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+        setTextColor(R.color.textNormal.getColor(context))
         setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
         addView(this)
       }

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/statistics/LibReferenceItemView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/statistics/LibReferenceItemView.kt
@@ -7,10 +7,10 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.content.ContextCompat
 import androidx.core.view.marginLeft
 import androidx.core.view.marginRight
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
 import com.absinthe.libchecker.utils.extensions.getResourceIdByAttr
 import com.absinthe.libchecker.view.AViewGroup
@@ -50,7 +50,7 @@ class LibReferenceItemView(context: Context) : MaterialCardView(context) {
         it.marginStart = 8.dp
         it.marginEnd = 8.dp
       }
-      setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+      setTextColor(R.color.textNormal.getColor(context))
       setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
       addView(this)
     }
@@ -64,7 +64,7 @@ class LibReferenceItemView(context: Context) : MaterialCardView(context) {
           it.marginStart = 8.dp
           it.marginEnd = 8.dp
         }
-        setTextColor(ContextCompat.getColor(context, R.color.textNormal))
+        setTextColor(R.color.textNormal.getColor(context))
         setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
         addView(this)
       }


### PR DESCRIPTION
- `ContextCompat` 内的部分获取资源的方法使用扩展方法封装，并替换用法
-  格式的问题可以用 `lintKotlin` 和 `formatKotlin` 这两个 gradle 任务处理，详见 kotlinter 的[说明文档](https://github.com/jeremymailen/kotlinter-gradle#Tasks)