### PR TITLE
Optimize gradle with buildSrc

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,9 +96,7 @@ val grpcVersion by extra("1.39.0")
 val protocVersion by extra("3.17.3")
 
 dependencies {
-  implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar", "*.aar"))))
   compileOnly(fileTree("ohos"))
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1-native-mt")
 
   implementation("com.github.zhaobozhen.libraries:me:1.0.2")
   implementation("com.github.zhaobozhen.libraries:utils:1.0.2")
@@ -128,7 +126,6 @@ dependencies {
   implementation("androidx.preference:preference-ktx:1.1.1")
   implementation("androidx.viewpager2:viewpager2:1.1.0-alpha01")
   implementation("androidx.recyclerview:recyclerview:1.2.1")
-  implementation("androidx.core:core-ktx:1.6.0")
 
   implementation("com.google.android.material:material:1.5.0-alpha01")
   implementation("com.github.CymChad:BaseRecyclerViewAdapterHelper:3.0.6")
@@ -169,10 +166,7 @@ dependencies {
   implementation("io.grpc:grpc-stub:$grpcVersion")
   implementation("javax.annotation:javax.annotation-api:1.3.2")
 
-  testImplementation("junit:junit:4.13.2")
   debugImplementation("com.squareup.leakcanary:leakcanary-android:2.7")
-  androidTestImplementation("androidx.test.ext:junit:1.1.3")
-  androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 }
 
 protobuf {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ import com.google.protobuf.gradle.id
 import com.google.protobuf.gradle.plugins
 import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
-import java.nio.charset.Charset
 import java.nio.file.Paths
 
 plugins {
@@ -16,23 +15,9 @@ plugins {
   id("com.google.protobuf")
 }
 
-android {
-  compileSdk = 31
-  buildToolsVersion = "31.0.0"
-
-  val gitCommitId = "git rev-parse --short HEAD".exec()
-  val baseVersionName = "2.1.4"
-  val verName = "${baseVersionName}.${gitCommitId}"
-  val verCode = "git rev-list --count HEAD".exec().toInt()
-
+setupAppModule {
   defaultConfig {
     applicationId = "com.absinthe.libchecker"
-    minSdk = 23
-    targetSdk = 31
-    versionCode = verCode
-    versionName = verName
-    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    resourceConfigurations += arrayOf("en", "zh-rCN", "zh-rTW", "ru", "uk-rUA")
   }
 
   buildFeatures {
@@ -44,30 +29,6 @@ android {
       arg("room.incremental", "true")
       arg("room.schemaLocation", "$projectDir/schemas")
     }
-  }
-
-  compileOptions {
-    targetCompatibility(JavaVersion.VERSION_11)
-    sourceCompatibility(JavaVersion.VERSION_11)
-  }
-
-  buildTypes {
-    debug {
-      applicationIdSuffix = ".debug"
-    }
-    release {
-      isMinifyEnabled = true
-      isShrinkResources = true
-      proguardFiles(
-        getDefaultProguardFile("proguard-android-optimize.txt"),
-        "proguard-rules.pro"
-      )
-    }
-  }
-
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
-    freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-XXLanguage:+InlineClasses")
   }
 
   sourceSets["main"].java.srcDirs("src/main/kotlin")
@@ -250,7 +211,4 @@ protobuf {
     }
   }
 }
-
-fun String.exec(): String = Runtime.getRuntime().exec(this).inputStream.readBytes()
-  .toString(Charset.defaultCharset()).trim()
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,21 @@ val protocVersion by extra("3.17.3")
 dependencies {
   compileOnly(fileTree("ohos"))
 
+  implementations(
+    Libs.activity,
+    Libs.fragment,
+    *Libs.lifecycle,
+    *Libs.room,
+    Libs.constraintLayout,
+    Libs.browser,
+    Libs.viewPager2,
+    Libs.recyclerView,
+    Libs.material,
+    Libs.coil,
+    *Libs.gson,
+    Libs.okHttp
+  )
+
   implementation("com.github.zhaobozhen.libraries:me:1.0.2")
   implementation("com.github.zhaobozhen.libraries:utils:1.0.2")
 
@@ -105,29 +120,11 @@ dependencies {
   implementation("com.microsoft.appcenter:appcenter-analytics:${appCenterSdkVersion}")
   implementation("com.microsoft.appcenter:appcenter-crashes:${appCenterSdkVersion}")
 
-  implementation("androidx.fragment:fragment-ktx:1.3.6")
-  implementation("androidx.activity:activity-ktx:1.3.0")
-  // Lifecycle
-  val lifecycleVersion = "2.3.1"
-  implementation("androidx.lifecycle:lifecycle-common-java8:${lifecycleVersion}")
-  implementation("androidx.lifecycle:lifecycle-livedata-ktx:${lifecycleVersion}")
-  implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:${lifecycleVersion}")
-  implementation("androidx.lifecycle:lifecycle-service:${lifecycleVersion}")
-
-  // Room components
-  val roomVersion = "2.3.0"
-  implementation("androidx.room:room-runtime:$roomVersion")
-  implementation("androidx.room:room-ktx:$roomVersion")
   kapt("org.xerial:sqlite-jdbc:3.36.0.1") //Work around on Apple Silicon
-  kapt("androidx.room:room-compiler:$roomVersion")
+  kapt(Libs.roomCompiler)
 
-  implementation("androidx.constraintlayout:constraintlayout:2.0.4")
-  implementation("androidx.browser:browser:1.3.0")
   implementation("androidx.preference:preference-ktx:1.1.1")
-  implementation("androidx.viewpager2:viewpager2:1.1.0-alpha01")
-  implementation("androidx.recyclerview:recyclerview:1.2.1")
 
-  implementation("com.google.android.material:material:1.5.0-alpha01")
   implementation("com.github.CymChad:BaseRecyclerViewAdapterHelper:3.0.6")
   implementation("com.github.PhilJay:MPAndroidChart:3.1.0")
   implementation("com.drakeet.about:about:2.4.1")
@@ -136,14 +133,11 @@ dependencies {
   implementation("com.jakewharton.timber:timber:4.7.1")
   implementation("com.jonathanfinerty.once:once:1.3.1")
   implementation("net.dongliu:apk-parser:2.6.10")
-  implementation("io.coil-kt:coil:1.3.1")
   implementation("me.zhanghai.android.fastscroll:library:1.1.7")
   implementation("me.zhanghai.android.appiconloader:appiconloader:1.3.1")
   implementation("org.lsposed.hiddenapibypass:hiddenapibypass:2.0")
   implementation("com.jakewharton:process-phoenix:2.1.1")
 
-  //Serialization
-  implementation("com.google.code.gson:gson:2.8.7")
   implementation("com.google.protobuf:protobuf-javalite:$protocVersion")
 
   implementation("dev.rikka.rikkax.appcompat:appcompat:1.2.0-rc01")
@@ -154,19 +148,13 @@ dependencies {
   implementation("dev.rikka.rikkax.preference:simplemenu-preference:1.0.3")
   implementation("dev.rikka.rikkax.insets:insets:1.1.0")
 
-  //Network
-  implementation("com.squareup.okhttp3:okhttp:4.9.1")
-  implementation("com.squareup.retrofit2:retrofit:2.9.0")
-  implementation("com.squareup.retrofit2:converter-gson:2.9.0")
-  implementation("com.squareup.okio:okio:2.10.0")
-
   // gRPC
   implementation("io.grpc:grpc-okhttp:$grpcVersion")
   implementation("io.grpc:grpc-protobuf-lite:$grpcVersion")
   implementation("io.grpc:grpc-stub:$grpcVersion")
   implementation("javax.annotation:javax.annotation-api:1.3.2")
 
-  debugImplementation("com.squareup.leakcanary:leakcanary-android:2.7")
+  debugImplementation(Libs.leakCanary)
 }
 
 protobuf {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,29 +1,28 @@
 import org.jmailen.gradle.kotlinter.KotlinterExtension
 
 buildscript {
+  apply("gradle/extra.gradle.kts")
+
   repositories {
     google()
     gradlePluginPortal()
   }
+
   dependencies {
-    classpath("com.android.tools.build:gradle:7.0.0")
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
+    classpath(rootProject.extra["androidPlugin"].toString())
+    classpath(rootProject.extra["kotlinPlugin"].toString())
     classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.17")
     classpath("org.jmailen.gradle:kotlinter-gradle:3.4.5")
   }
 }
 
 allprojects {
+  apply("$rootDir/gradle/extra.gradle.kts")
+
   apply(plugin = "org.jmailen.kotlinter")
 
   configure<KotlinterExtension> {
     indentSize = 2
-  }
-
-  repositories {
-    google()
-    mavenCentral()
-    maven("https://jitpack.io")
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     classpath(rootProject.extra["androidPlugin"].toString())
     classpath(rootProject.extra["kotlinPlugin"].toString())
     classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.17")
-    classpath("org.jmailen.gradle:kotlinter-gradle:3.4.5")
+    classpath(Libs.kotlinterPlugin)
   }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+  `kotlin-dsl`
+}
+
+apply("../gradle/extra.gradle.kts")
+
+dependencies {
+  implementation(rootProject.extra["androidPlugin"].toString())
+  implementation(rootProject.extra["kotlinPlugin"].toString())
+}

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -1,0 +1,49 @@
+@file:Suppress("SpellCheckingInspection")
+
+private const val lifecycleVersion = "2.3.1"
+private const val retrofitVersion = "2.9.0"
+private const val roomVersion = "2.3.0"
+
+object Libs {
+  const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
+  const val core = "androidx.core:core-ktx:1.6.0"
+  const val appCompat = "androidx.appcompat:appcompat:1.3.1"
+  const val annotation = "androidx.annotation:annotation:1.2.0"
+  const val activity = "androidx.activity:activity-ktx:1.3.0"
+  const val fragment = "androidx.fragment:fragment-ktx:1.3.6"
+  const val constraintLayout = "androidx.constraintlayout:constraintlayout:2.1.0"
+  const val material = "com.google.android.material:material:1.5.0-alpha01"
+  const val recyclerView = "androidx.recyclerview:recyclerview:1.2.1"
+  const val leakCanary = "com.squareup.leakcanary:leakcanary-android:2.7"
+  const val okHttp = "com.squareup.okhttp3:okhttp:4.9.1"
+  const val retrofit = "com.squareup.retrofit2:retrofit:$retrofitVersion"
+  const val viewPager2 = "androidx.viewpager2:viewpager2:1.1.0-alpha01"
+  const val browser = "androidx.browser:browser:1.3.0"
+  const val coil = "io.coil-kt:coil:1.3.1"
+
+  const val kotlinterPlugin = "org.jmailen.gradle:kotlinter-gradle:3.4.5"
+
+  const val roomCompiler = "androidx.room:room-compiler:$roomVersion"
+
+  val tests = arrayOf(
+    "junit:junit:4.13.2"
+  )
+  val androidTests = arrayOf(
+    "androidx.test.ext:junit:1.1.3",
+    "androidx.test.espresso:espresso-core:3.4.0"
+  )
+  val lifecycle = arrayOf(
+    "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion",
+    "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion",
+    "androidx.lifecycle:lifecycle-service:$lifecycleVersion",
+    "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
+  )
+  val room = arrayOf(
+    "androidx.room:room-runtime:$roomVersion",
+    "androidx.room:room-ktx:$roomVersion"
+  )
+  val gson = arrayOf(
+    "com.google.code.gson:gson:2.8.7",
+    "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+  )
+}

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -1,0 +1,68 @@
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import java.nio.charset.Charset
+
+const val baseVersionName = "2.1.4"
+val verName: String by lazy { "${baseVersionName}.${"git rev-parse --short HEAD".exec()}" }
+val verCode: Int by lazy { "git rev-list --count HEAD".exec().toInt() }
+
+fun Project.setupLibraryModule(block: LibraryExtension.() -> Unit = {}) {
+  setupBaseModule(block)
+}
+
+fun Project.setupAppModule(block: BaseAppModuleExtension.() -> Unit = {}) {
+  setupBaseModule<BaseAppModuleExtension> {
+    defaultConfig {
+      versionCode = verCode
+      versionName = verName
+      resourceConfigurations += arrayOf("en", "zh-rCN", "zh-rTW", "ru", "uk-rUA")
+    }
+    buildTypes {
+      debug {
+        applicationIdSuffix = ".debug"
+      }
+      release {
+        isMinifyEnabled = true
+        isShrinkResources = true
+        proguardFiles(
+          getDefaultProguardFile("proguard-android-optimize.txt"),
+          "proguard-rules.pro"
+        )
+      }
+    }
+    block()
+  }
+}
+
+private inline fun <reified T : BaseExtension> Project.setupBaseModule(crossinline block: T.() -> Unit = {}) {
+  extensions.configure<BaseExtension>("android") {
+    compileSdkVersion(31)
+    buildToolsVersion = "31.0.0"
+    defaultConfig {
+      minSdk = 23
+      targetSdk = 31
+      testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.toString()
+      freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-XXLanguage:+InlineClasses")
+    }
+    compileOptions {
+      targetCompatibility(JavaVersion.VERSION_11)
+      sourceCompatibility(JavaVersion.VERSION_11)
+    }
+    (this as T).block()
+  }
+}
+
+private fun BaseExtension.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
+  (this as ExtensionAware).extensions.configure("kotlinOptions", block)
+}
+
+fun String.exec(): String = Runtime.getRuntime().exec(this).inputStream.readBytes()
+  .toString(Charset.defaultCharset()).trim()

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -62,16 +62,13 @@ private inline fun <reified T : BaseExtension> Project.setupBaseModule(crossinli
     dependencies {
       implementations(
         fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar", "*.aar"))),
-        "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1-native-mt",
-        "androidx.appcompat:appcompat:1.3.1",
-        "androidx.core:core-ktx:1.6.0"
+        Libs.coroutines,
+        Libs.appCompat,
+        Libs.core
       )
 
-      testImplementations("junit:junit:4.13.2")
-      androidTestImplementations(
-        "androidx.test.ext:junit:1.1.3",
-        "androidx.test.espresso:espresso-core:3.4.0"
-      )
+      testImplementations(*Libs.tests)
+      androidTestImplementations(*Libs.androidTests)
     }
     (this as T).block()
   }

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -3,7 +3,10 @@ import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.dependencies
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 import java.nio.charset.Charset
 
@@ -56,6 +59,20 @@ private inline fun <reified T : BaseExtension> Project.setupBaseModule(crossinli
       targetCompatibility(JavaVersion.VERSION_11)
       sourceCompatibility(JavaVersion.VERSION_11)
     }
+    dependencies {
+      implementations(
+        fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar", "*.aar"))),
+        "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1-native-mt",
+        "androidx.appcompat:appcompat:1.3.1",
+        "androidx.core:core-ktx:1.6.0"
+      )
+
+      testImplementations("junit:junit:4.13.2")
+      androidTestImplementations(
+        "androidx.test.ext:junit:1.1.3",
+        "androidx.test.espresso:espresso-core:3.4.0"
+      )
+    }
     (this as T).block()
   }
 }
@@ -66,3 +83,15 @@ private fun BaseExtension.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
 
 fun String.exec(): String = Runtime.getRuntime().exec(this).inputStream.readBytes()
   .toString(Charset.defaultCharset()).trim()
+
+fun DependencyHandler.implementations(vararg names: Any): Array<Dependency?> =
+  config("implementation", *names)
+
+fun DependencyHandler.androidTestImplementations(vararg names: Any): Array<Dependency?> =
+  config("androidTestImplementation", *names)
+
+fun DependencyHandler.testImplementations(vararg names: Any): Array<Dependency?> =
+  config("testImplementation", *names)
+
+private fun DependencyHandler.config(operation: String, vararg names: Any): Array<Dependency?> =
+  names.map { add(operation, it) }.toTypedArray()

--- a/gradle/extra.gradle.kts
+++ b/gradle/extra.gradle.kts
@@ -1,0 +1,10 @@
+rootProject.extra.run {
+  set("androidPlugin", "com.android.tools.build:gradle:7.0.0")
+  set("kotlinPlugin", "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
+}
+
+repositories {
+  google()
+  mavenCentral()
+  maven("https://jitpack.io")
+}

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -4,12 +4,4 @@ plugins {
   kotlin("kapt")
 }
 
-setupLibraryModule {
-  packagingOptions.resources.excludes += setOf(
-    "META-INF/atomicfu.kotlin_module"
-  )
-}
-
-dependencies {
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1-native-mt")
-}
+setupLibraryModule()

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
   implementation("androidx.core:core-ktx:1.6.0")
 
   testImplementation("junit:junit:4.13.2")
-  debugImplementation("com.squareup.leakcanary:leakcanary-android:2.7")
   androidTestImplementation("androidx.test.ext:junit:1.1.3")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -11,13 +11,5 @@ setupLibraryModule {
 }
 
 dependencies {
-  implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar", "*.aar"))))
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1-native-mt")
-
-  implementation("androidx.appcompat:appcompat:1.3.1")
-  implementation("androidx.core:core-ktx:1.6.0")
-
-  testImplementation("junit:junit:4.13.2")
-  androidTestImplementation("androidx.test.ext:junit:1.1.3")
-  androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -4,40 +4,7 @@ plugins {
   kotlin("kapt")
 }
 
-android {
-  compileSdk = 31
-  buildToolsVersion = "31.0.0"
-
-  defaultConfig {
-    minSdk = 23
-    targetSdk = 31
-    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-  }
-
-  buildFeatures {
-    viewBinding = true
-  }
-
-  buildTypes {
-    release {
-      isMinifyEnabled = true
-      proguardFiles(
-        getDefaultProguardFile("proguard-android-optimize.txt"),
-        "proguard-rules.pro"
-      )
-    }
-  }
-
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
-    freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-XXLanguage:+InlineClasses")
-  }
-
-  compileOptions {
-    targetCompatibility(JavaVersion.VERSION_11)
-    sourceCompatibility(JavaVersion.VERSION_11)
-  }
-
+setupLibraryModule {
   packagingOptions.resources.excludes += setOf(
     "META-INF/atomicfu.kotlin_module"
   )


### PR DESCRIPTION
- 添加 buildSrc 模块，封装 `setupAppModule`, `setupBaseModule` 等方法，复用模块的配置
- 添加 `Libs.kt`，复用各个依赖，还有部分 app 模块下的依赖懒得加进去了，你可以把剩余的都加进去，统一管理
- 这样做的好处是封装重复的配置，方便日后组件化等操作；坏处是 dependabot 用不了了，以后手动升级依赖。