### PR TITLE
Enable type-safe project accessors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,7 +99,7 @@ configurations.all {
 
 dependencies {
   compileOnly(fileTree("ohos"))
-  compileOnly(project(":hidden-api"))
+  compileOnly(projects.hiddenApi)
 
   implementations(
     // UI

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,4 @@
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 include(":app", ":sdk", ":hidden-api")
 rootProject.name = "LibChecker"


### PR DESCRIPTION
1/2 of #181.