### PR TITLE
Add Blocker integration

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/integrations/blocker/BlockerManager.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/integrations/blocker/BlockerManager.kt
@@ -1,0 +1,86 @@
+package com.absinthe.libchecker.integrations.blocker
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.core.os.bundleOf
+import com.absinthe.libchecker.annotation.ACTIVITY
+import com.absinthe.libchecker.annotation.LibType
+import com.absinthe.libchecker.annotation.PROVIDER
+import com.absinthe.libchecker.annotation.RECEIVER
+import com.absinthe.libchecker.annotation.SERVICE
+import com.absinthe.libchecker.integrations.monkeyking.ShareCmpInfo
+import com.absinthe.libchecker.utils.PackageUtils
+import com.absinthe.libchecker.utils.fromJson
+import com.absinthe.libchecker.utils.showToast
+import com.absinthe.libchecker.utils.toJson
+
+const val TYPE_ACTIVITY = "activity"
+const val TYPE_SERVICE = "service"
+const val TYPE_RECEIVER = "receiver"
+const val TYPE_PROVIDER = "provider"
+
+private const val URI_AUTHORIZATION = "content://com.merxury.blocker.provider.ComponentProvider/"
+private const val BLOCKER_APPLICATION_ID = "com.merxury.blocker"
+private const val FIRST_SUPPORT_VERSION_CODE = 1264
+
+class BlockerManager {
+
+  fun queryBlockedComponent(context: Context, packageName: String): List<ShareCmpInfo.Component> {
+    val contentResolver = context.contentResolver
+    val uri = Uri.parse(URI_AUTHORIZATION)
+    return try {
+      val bundle = contentResolver.call(uri, "getComponents", packageName, null)
+      val shareCmpInfoString = bundle?.getString("cmp_list") ?: return emptyList()
+      shareCmpInfoString.fromJson<ShareCmpInfo>()?.components ?: emptyList()
+    } catch (e: Throwable) {
+      emptyList()
+    }
+  }
+
+  fun addBlockedComponent(
+    context: Context,
+    packageName: String,
+    componentName: String,
+    @LibType type: Int,
+    shouldBlock: Boolean
+  ) {
+    val fullComponentName = if (componentName.startsWith(".")) {
+      packageName + componentName
+    } else {
+      componentName
+    }
+    val shareCmpInfo = ShareCmpInfo(
+      packageName,
+      listOf(
+        ShareCmpInfo.Component(
+          type = getType(type),
+          name = fullComponentName,
+          block = shouldBlock
+        )
+      )
+    )
+    val bundle = bundleOf(
+      "cmp_list" to shareCmpInfo.toJson()
+    )
+    try {
+      context.contentResolver.call(URI_AUTHORIZATION.toUri(), "blocks", packageName, bundle)
+    } catch (e: Exception) {
+      context.showToast(e.message.toString())
+    }
+  }
+
+  private fun getType(@LibType type: Int): String = when (type) {
+    ACTIVITY -> TYPE_ACTIVITY
+    SERVICE -> TYPE_SERVICE
+    RECEIVER -> TYPE_RECEIVER
+    PROVIDER -> TYPE_PROVIDER
+    else -> throw IllegalStateException("wrong type")
+  }
+
+  companion object {
+    val isSupportInteraction =
+      PackageUtils.isAppInstalled(BLOCKER_APPLICATION_ID) &&
+        PackageUtils.getVersionCode(BLOCKER_APPLICATION_ID) >= FIRST_SUPPORT_VERSION_CODE
+  }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -176,6 +176,8 @@
   <!--  Integration  -->
   <string name="integration_monkey_king_menu_block">Заблокировать с помощью \"MonkeyKing Purify\"</string>
   <string name="integration_monkey_king_menu_unblock">Разблокировать с помощью \"MonkeyKing Purify\"</string>
+  <string name="integration_blocker_menu_block">Заблокировать через \"Blocker\"</string>
+  <string name="integration_blocker_menu_unblock">Разблокировать через \"Blocker\"</string>
   <string name="integration_anywhere_menu_editor">Открыть в \"Anywhere- Editor\"</string>
 
   <!--  Cloud rules  -->

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -176,6 +176,8 @@
   <!--  Integration  -->
   <string name="integration_monkey_king_menu_block">Заблокувати з допомогою \"MonkeyKing Purify\"</string>
   <string name="integration_monkey_king_menu_unblock">Розблокувати з допомогою \"MonkeyKing Purify\"</string>
+  <string name="integration_blocker_menu_block">Заблокувати через \"Blocker\"</string>
+  <string name="integration_blocker_menu_unblock">Розблокуйте його через \"Blocker\"</string>
   <string name="integration_anywhere_menu_editor">Відкрити в \"Anywhere- Editor\"</string>
 
   <!--  Cloud rules  -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -177,6 +177,8 @@
   <!--  Integration  -->
   <string name="integration_monkey_king_menu_block">使用「大聖淨化」禁用此組件</string>
   <string name="integration_monkey_king_menu_unblock">使用「大聖淨化」解禁此組件</string>
+  <string name="integration_blocker_menu_block">使用「Blocker」禁用此組件</string>
+  <string name="integration_blocker_menu_unblock">使用「Blocker」解禁此組件</string>
   <string name="integration_anywhere_menu_editor">在「Anywhere- 編輯器」中打開</string>
 
   <!--  Cloud rules  -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -177,6 +177,8 @@
   <!--  Integration  -->
   <string name="integration_monkey_king_menu_block">使用「大圣净化」禁用此组件</string>
   <string name="integration_monkey_king_menu_unblock">使用「大圣净化」解禁此组件</string>
+  <string name="integration_blocker_menu_block">使用「Blocker」禁用此组件</string>
+  <string name="integration_blocker_menu_unblock">使用「Blocker」解禁此组件</string>
   <string name="integration_anywhere_menu_editor">在「Anywhere- 编辑器」中打开</string>
 
   <!--  Cloud rules  -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,8 @@
   <!--  Integration  -->
   <string name="integration_monkey_king_menu_block">Block it via \"MonkeyKing Purify\"</string>
   <string name="integration_monkey_king_menu_unblock">Unblock it via \"MonkeyKing Purify\"</string>
+  <string name="integration_blocker_menu_block">Block it via \"Blocker\"</string>
+  <string name="integration_blocker_menu_unblock">Unblock it via \"Blocker\"</string>
   <string name="integration_anywhere_menu_editor">Open it in \"Anywhere- Editor\"</string>
 
   <!--  Cloud rules  -->


### PR DESCRIPTION
Add Blocker integration:
Users can disable/enable app components by long clicking the component name.
It will show the item 'Block it via Blocker' or 'Unblock it via Blocker'. After selecting the options, LibChecker will use the ContentProvider to call Blocker to control components. 