### PR TITLE
fix: use correct protoc binary for macOS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -181,9 +181,12 @@ dependencies {
 
 protobuf {
   protoc {
-    artifact = if (osdetector.os == "osx")
-      "${libs.google.protobuf.protoc.get()}:osx-aarch_64"
-    else
+    artifact = if (osdetector.os == "osx") {
+      // support both Apple Silicon and Intel chipsets
+      val arch = System.getProperty("os.arch")
+      val suffix = if (arch == "x86_64") "x86_64" else "aarch_64"
+      "${libs.google.protobuf.protoc.get()}:osx-$suffix"
+    } else
       libs.google.protobuf.protoc.get().toString()
   }
   plugins {


### PR DESCRIPTION
Fix a build error in Apple Intel chips, which caused by protoc.

On macOS,
* for Apple Silicon chips, use `protoc-{x.y.z}-osx-aarch_64.exe`
* for Intel chips, use `protoc-{x.y.z}-osx-x86_64.exe`

