### PR TITLE
Configure Qodana

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -6,6 +6,9 @@ on:
       - master
       - 'releases/*'
 
+env:
+  APP_CENTER_SECRET: ${{secrets.APP_CENTER_SECRET}}
+
 jobs:
   qodana:
     runs-on: ubuntu-latest
@@ -14,8 +17,24 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-java@v3.4.1
+        with:
+          distribution: 'zulu'
+          java-version: 17
+      - uses: gradle/wrapper-validation-action@v1.0.4
+      - name: Initialize Gradle Project
+        uses: gradle/gradle-build-action@v2.2.2
+        with:
+          arguments: build
+
+      # Initialize Gradle Project to build BuildConfig.java
+
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2022.2.1
+        with:
+          args: scan,-l,jetbrains/qodana-jvm-android,--yaml-name,qodana.yaml
+          use-caches: false
+          # DO NOT USE CACHES. Leads to fail
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -17,13 +17,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v3.4.1
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 17
-      - uses: gradle/wrapper-validation-action@v1.0.4
+      - uses: gradle/wrapper-validation-action@v1
       - name: Initialize Gradle Project
-        uses: gradle/gradle-build-action@v2.2.2
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: build
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,8 @@
+# Qodana configuration:
+# https://www.jetbrains.com/help/qodana/qodana-yaml.html
+version: 1.0
+profile:
+  name: qodana.recommended
+exclude:
+  - name: AndroidUnknownAttribute
+  # Disable Unknown Attributes check when target API is 33 before AGP 7.3 release


### PR DESCRIPTION
Qodana-github-action use qodana-jvm-community by default.
* We need to manually convert to qodana-jvm-android
```shell
-l jetbrains/qodana-jvm-android
```
which means 
```yaml
args: -l,jetbrains/qodana-jvm-android
```

* And then override `qodana.yaml` to manually configured one
```shell
--yaml-name qodana.yaml
```
which means 
```yaml
args: --yaml-name,qodana.yaml
```

* And disable cache.

Cache will cause a failure
```yaml
use-caches: false
```