### PR TITLE
Android 13 gesture navigation bar height is 24dp

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/about/AbsAboutActivityProxy.java
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/about/AbsAboutActivityProxy.java
@@ -133,7 +133,7 @@ public abstract class AbsAboutActivityProxy extends MaterialActivity {
       @Override
       public WindowInsetsCompat onApplyWindowInsets(View v, WindowInsetsCompat windowInsets) {
         Insets navigationBarsInsets = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars());
-        boolean isGestureNavigation = navigationBarsInsets.bottom <= 20 * getResources().getDisplayMetrics().density;
+        boolean isGestureNavigation = navigationBarsInsets.bottom <= 24 * getResources().getDisplayMetrics().density;
 
         if (!isGestureNavigation) {
           ViewCompat.onApplyWindowInsets(decorView, windowInsets);


### PR DESCRIPTION
So this commit fixes the original inaccurate `isGestureNavigation` determination.

On Android 13:
(See the bottom navigation bar)

| Before | After |
| --- | --- |
| ![Screenshot_before](https://user-images.githubusercontent.com/5214214/186584121-2596c6b1-8654-4d57-a93e-8fc171915281.png) | ![Screenshot_after](https://user-images.githubusercontent.com/5214214/186583338-e263851e-cc6d-4ff6-bcae-09f8d2fcb9f5.png) |
 