### PR TITLE
Avoid BottomNavigationView being pushed up by soft keyboard

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
@@ -12,6 +12,11 @@ import android.os.Looper
 import android.view.View
 import androidx.activity.viewModels
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import androidx.core.view.updatePaddingRelative
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -217,7 +222,23 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), INavViewContainer, IAp
           true
         }
         setOnClickListener { /*Do nothing*/ }
+        fixBottomNavigationViewInsets(this)
       }
+    }
+  }
+
+  /**
+   * 覆盖掉 BottomNavigationView 内部的 OnApplyWindowInsetsListener 并避免其被软键盘顶起来
+   * @see BottomNavigationView.applyWindowInsets
+   */
+  private fun fixBottomNavigationViewInsets(view: BottomNavigationView) {
+    ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
+      // 这里不直接使用 windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
+      // 因为它的结果可能受到 insets 传播链上层某环节的影响，出现了错误的 navigationBarsInsets
+      val navigationBarsInsets =
+        ViewCompat.getRootWindowInsets(view)!!.getInsets(WindowInsetsCompat.Type.navigationBars())
+      view.updatePadding(bottom = navigationBarsInsets.bottom)
+      windowInsets
     }
   }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
@@ -12,11 +12,9 @@ import android.os.Looper
 import android.view.View
 import androidx.activity.viewModels
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
-import androidx.core.view.updatePaddingRelative
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter


### PR DESCRIPTION
BottomNavigationView should not be pushed up when we focus on the search bar.

The root cause is that Google's source code uses the wrong `insets.getSystemWindowInsetBottom()`, which includes the height of the soft keyboard, not just "the system navigation bar" as written in Google's comment:

![image](https://user-images.githubusercontent.com/5214214/186591363-3bc37064-e45a-4d41-bc9c-4dccd235d293.png)

| Before | After |
| --- | --- |
| ![Screenshot_378_before](https://user-images.githubusercontent.com/5214214/186591736-b1c0df0d-7e72-46be-8da2-f159144aa61c.png) | ![Screenshot_378_after](https://user-images.githubusercontent.com/5214214/186591762-659d3838-0c3b-43a5-8f6a-5f381e61d81e.png) |