### PR TITLE
Fix toast memory leak

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/Toasty.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/Toasty.kt
@@ -23,12 +23,6 @@ object Toasty {
   private val handler = Handler(Looper.getMainLooper())
   private var toast: Toast? = null
 
-  fun cancel(needCancel: Boolean, parent: Toast? = null) {
-    if (needCancel) toast?.cancel()
-    if (parent != toast && parent != null) return
-    toast = null
-  }
-
   @AnyThread
   fun showShort(context: Context, message: String) {
     if (Looper.getMainLooper().thread === Thread.currentThread()) {
@@ -62,19 +56,13 @@ object Toasty {
   @Suppress("deprecation")
   @MainThread
   private fun show(context: Context, message: String, duration: Int) {
-    cancel(true)
+    toast?.cancel()
 
     WeakReference(context).get()?.let { ctx ->
       if (OsUtils.atLeastR() && context !is ContextThemeWrapper) {
         Toast(ctx).also {
           it.duration = duration
           it.setText(message)
-          it.addCallback(object : Toast.Callback() {
-            override fun onToastHidden() {
-              super.onToastHidden()
-              cancel(false)
-            }
-          })
           toast = it
         }.show()
       } else {
@@ -85,7 +73,6 @@ object Toasty {
           it.setGravity(Gravity.CENTER_HORIZONTAL or Gravity.BOTTOM, 0, 200)
           it.duration = duration
           it.view = view
-          view.parent = it
           toast = it
         }.show()
       }

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/Toasty.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/Toasty.kt
@@ -21,7 +21,7 @@ import java.lang.ref.WeakReference
 object Toasty {
 
   private val handler = Handler(Looper.getMainLooper())
-  private var toast: Toast? = null
+  private var toast: WeakReference<Toast>? = null
 
   @AnyThread
   fun showShort(context: Context, message: String) {
@@ -56,14 +56,14 @@ object Toasty {
   @Suppress("deprecation")
   @MainThread
   private fun show(context: Context, message: String, duration: Int) {
-    toast?.cancel()
+    toast?.get()?.cancel()
 
     WeakReference(context).get()?.let { ctx ->
       if (OsUtils.atLeastR() && context !is ContextThemeWrapper) {
         Toast(ctx).also {
           it.duration = duration
           it.setText(message)
-          toast = it
+          toast = WeakReference(it)
         }.show()
       } else {
         val view = ToastView(ctx).also {
@@ -73,7 +73,7 @@ object Toasty {
           it.setGravity(Gravity.CENTER_HORIZONTAL or Gravity.BOTTOM, 0, 200)
           it.duration = duration
           it.view = view
-          toast = it
+          toast = WeakReference(it)
         }.show()
       }
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/app/ToastView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/app/ToastView.kt
@@ -4,11 +4,9 @@ import android.content.Context
 import android.graphics.Color
 import android.view.Gravity
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
 import com.absinthe.libchecker.R
-import com.absinthe.libchecker.utils.Toasty
 import com.absinthe.libchecker.view.AViewGroup
 
 class ToastView(context: Context) : AViewGroup(context) {
@@ -25,8 +23,6 @@ class ToastView(context: Context) : AViewGroup(context) {
     setBackgroundResource(R.drawable.bg_toast)
     addView(this)
   }
-
-  var parent: Toast? = null
 
   private val icon = AppCompatImageView(context).apply {
     layoutParams = LayoutParams(24.dp, 24.dp)
@@ -47,10 +43,5 @@ class ToastView(context: Context) : AViewGroup(context) {
   override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
     icon.let { it.layout(it.toHorizontalCenter(this), 0) }
     message.layout(0, icon.measuredHeight / 2)
-  }
-
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    Toasty.cancel(false, parent)
   }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/app/ToastView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/app/ToastView.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import android.graphics.Color
 import android.view.Gravity
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
 import com.absinthe.libchecker.R
+import com.absinthe.libchecker.utils.Toasty
 import com.absinthe.libchecker.view.AViewGroup
 
 class ToastView(context: Context) : AViewGroup(context) {
@@ -23,6 +25,8 @@ class ToastView(context: Context) : AViewGroup(context) {
     setBackgroundResource(R.drawable.bg_toast)
     addView(this)
   }
+
+  var parent: Toast? = null
 
   private val icon = AppCompatImageView(context).apply {
     layoutParams = LayoutParams(24.dp, 24.dp)
@@ -43,5 +47,10 @@ class ToastView(context: Context) : AViewGroup(context) {
   override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
     icon.let { it.layout(it.toHorizontalCenter(this), 0) }
     message.layout(0, icon.measuredHeight / 2)
+  }
+
+  override fun onDetachedFromWindow() {
+    super.onDetachedFromWindow()
+    Toasty.cancel(false, parent)
   }
 }


### PR DESCRIPTION
```
┬───
│ GC Root: Input or output parameters in native code
│
├─ dalvik.system.PathClassLoader instance
│    Leaking: NO (Toasty↓ is not leaking and A ClassLoader is never leaking)
│    ↓ ClassLoader.runtimeInternalObjects
├─ java.lang.Object[] array
│    Leaking: NO (Toasty↓ is not leaking)
│    ↓ Object[1574]
├─ com.absinthe.libchecker.utils.Toasty class
│    Leaking: NO (a class is never leaking)
│    ↓ static Toasty.toast
│                    ~~~~~
├─ android.widget.Toast instance
│    Leaking: YES (This toast is done showing (Toast.mTN.mWM != null && Toast.mTN.mView == null))
│    Retaining 3.6 MB in 59102 objects
│    mContext instance of com.absinthe.libchecker.ui.main.MainActivity with mDestroyed = true
│    ↓ Toast.mContext
╰→ com.absinthe.libchecker.ui.main.MainActivity instance
     Leaking: YES (ObjectWatcher was watching this because com.absinthe.libchecker.ui.main.MainActivity received
     Activity#onDestroy() callback and Activity#mDestroyed is true)
     Retaining 2.8 MB in 58775 objects
     key = 59b5178e-56d0-4fd4-80c2-5425a1f22169
     watchDurationMillis = 5149
     retainedDurationMillis = 147
     mApplication instance of com.absinthe.libchecker.LibCheckerApp
     mBase instance of android.app.ContextImpl
```