### PR TITLE
Count X86 and X86_64 in ABI chart

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
@@ -63,6 +63,9 @@ private const val TYPE_KOTLIN = 1
 private const val TYPE_TARGET_API = 2
 private const val TYPE_MIN_SDK = 3
 
+private val ABI_64_BIT = setOf(ARMV8, X86_64)
+private val ABI_32_BIT = setOf(ARMV5, ARMV7, X86)
+
 class ChartFragment :
   BaseFragment<FragmentPieChartBinding>(),
   OnChartValueSelectedListener,
@@ -141,8 +144,8 @@ class ChartFragment :
             if (item.isSystem) continue
           }
           when (item.abi % 10) {
-            ARMV8, X86_64 -> list[0]++
-            ARMV5, ARMV7, X86 -> list[1]++
+            in ABI_64_BIT -> list[0]++
+            in ABI_32_BIT -> list[1]++
             else -> list[2]++
           }
         }
@@ -463,7 +466,7 @@ class ChartFragment :
                 getString(R.string.title_statistics_dialog),
                 getString(R.string.string_64_bit)
               )
-              filteredList?.filter { (it.abi % MULTI_ARCH) == ARMV8 || (it.abi % MULTI_ARCH) == X86_64 }
+              filteredList?.filter { (it.abi % MULTI_ARCH) in ABI_64_BIT }
                 ?.let { filter ->
                   item = ArrayList(filter)
                 }
@@ -473,7 +476,7 @@ class ChartFragment :
                 getString(R.string.title_statistics_dialog),
                 getString(R.string.string_32_bit)
               )
-              filteredList?.filter { (it.abi % MULTI_ARCH) == ARMV7 || (it.abi % MULTI_ARCH) == ARMV5 || (it.abi % MULTI_ARCH) == X86 }
+              filteredList?.filter { (it.abi % MULTI_ARCH) in ABI_32_BIT }
                 ?.let { filter ->
                   item = ArrayList(filter)
                 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
@@ -17,6 +17,8 @@ import com.absinthe.libchecker.constant.Constants.ARMV7
 import com.absinthe.libchecker.constant.Constants.ARMV8
 import com.absinthe.libchecker.constant.Constants.MULTI_ARCH
 import com.absinthe.libchecker.constant.Constants.NO_LIBS
+import com.absinthe.libchecker.constant.Constants.X86
+import com.absinthe.libchecker.constant.Constants.X86_64
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.database.entity.Features
 import com.absinthe.libchecker.database.entity.LCItem
@@ -139,8 +141,8 @@ class ChartFragment :
             if (item.isSystem) continue
           }
           when (item.abi % 10) {
-            ARMV8 -> list[0]++
-            ARMV5, ARMV7 -> list[1]++
+            ARMV8, X86_64 -> list[0]++
+            ARMV5, ARMV7, X86 -> list[1]++
             else -> list[2]++
           }
         }
@@ -461,7 +463,7 @@ class ChartFragment :
                 getString(R.string.title_statistics_dialog),
                 getString(R.string.string_64_bit)
               )
-              filteredList?.filter { (it.abi % MULTI_ARCH) == ARMV8 }
+              filteredList?.filter { (it.abi % MULTI_ARCH) == ARMV8 || (it.abi % MULTI_ARCH) == X86_64 }
                 ?.let { filter ->
                   item = ArrayList(filter)
                 }
@@ -471,7 +473,7 @@ class ChartFragment :
                 getString(R.string.title_statistics_dialog),
                 getString(R.string.string_32_bit)
               )
-              filteredList?.filter { (it.abi % MULTI_ARCH) == ARMV7 || (it.abi % MULTI_ARCH) == ARMV5 }
+              filteredList?.filter { (it.abi % MULTI_ARCH) == ARMV7 || (it.abi % MULTI_ARCH) == ARMV5 || (it.abi % MULTI_ARCH) == X86 }
                 ?.let { filter ->
                   item = ArrayList(filter)
                 }


### PR DESCRIPTION
This PR needs to be evaluated.
I found the code for the first commit, which shows that we didn't count X86 and X86_64 initially. I don't know if we should count X86.

BTW, Fix #444.