### PR TITLE
Improve Bangcle Check

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/LCAppUtils.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/LCAppUtils.kt
@@ -121,7 +121,7 @@ object LCAppUtils {
   }
 
   private val checkNativeLibs =
-    listOf("libjiagu.so", "libjiagu_a64.so", "libjiagu_x86.so", "libjiagu_x64.so", "libsecexe.so", "libSecShell.so", "libSecShell-x86.so", "libDexHelper.so", "libDexHelper-x86.so", "libDexHelper-x86_64.so", "libdexjni.so", "libapp.so")
+    listOf("libjiagu.so", "libjiagu_a64.so", "libjiagu_x86.so", "libjiagu_x64.so", "libDexHelper.so", "libDexHelper-x86.so", "libdexjni.so", "libapp.so")
   fun checkNativeLibValidation(
     packageName: String,
     nativeLib: String,
@@ -142,7 +142,7 @@ object LCAppUtils {
           ).any { it == "com.qihoo.util.*".toClassDefType() }
         }.getOrDefault(false)
       }
-      "libsecexe.so", "libSecShell.so", "libSecShell-x86.so", "libDexHelper.so", "libDexHelper-x86.so", "libDexHelper-x86_64.so", "libdexjni.so" -> {
+      "libDexHelper.so", "libDexHelper-x86.so", "libdexjni.so" -> {
         runCatching {
           PackageUtils.findDexClasses(
             source,


### PR DESCRIPTION
The so files generated by Bangcle are now mainly `libDexHelper.so`, `libDexHelper-x86.so`, `libdexjni.so`, and the so files with the same name added by other applications are mostly `libDexHelper.so`. Other so files generated by Bangcle in the rules of LibChecker may be the other version of Bangcle. The apk entry class of Bangcle in other rules is `com.secshell.shellwrapper.SecAppWrapper` according to the document online, which is not consistent with the current, so this can prevent the other version of Bangcle from being affected.