### PR TITLE
Add `lcss` file support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,8 +77,8 @@
       android:label="@string/title_album" />
     <activity
       android:name=".ui.album.BackupActivity"
-      android:label="@string/album_item_backup_restore_title"
-      android:exported="true">
+      android:exported="true"
+      android:label="@string/album_item_backup_restore_title">
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,7 +77,16 @@
       android:label="@string/title_album" />
     <activity
       android:name=".ui.album.BackupActivity"
-      android:label="@string/album_item_backup_restore_title" />
+      android:label="@string/album_item_backup_restore_title"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:scheme="content" />
+        <data android:mimeType="*/*" />
+        <data android:pathPattern=".*\\.lcss" />
+      </intent-filter>
+    </activity>
     <activity
       android:name=".ui.album.ComparisonActivity"
       android:label="@string/album_item_comparison_title"

--- a/app/src/main/kotlin/com/absinthe/libchecker/database/LCDao.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/database/LCDao.kt
@@ -64,10 +64,10 @@ interface LCDao {
   @Query("SELECT * from snapshot_table WHERE timeStamp LIKE :timestamp ORDER BY packageName ASC")
   fun getSnapshotsFlow(timestamp: Long): Flow<List<SnapshotItem>>
 
-  @Insert(onConflict = OnConflictStrategy.IGNORE)
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun insert(item: SnapshotItem)
 
-  @Insert(onConflict = OnConflictStrategy.IGNORE)
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun insertSnapshots(items: List<SnapshotItem>)
 
   @Update
@@ -92,7 +92,7 @@ interface LCDao {
   fun deleteSnapshots(list: List<SnapshotItem>)
 
   // TimeStamp Table
-  @Insert(onConflict = OnConflictStrategy.IGNORE)
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun insert(item: TimeStampItem)
 
   @Query("SELECT * from timestamp_table ORDER BY timestamp DESC")

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
@@ -1,7 +1,9 @@
 package com.absinthe.libchecker.ui.album
 
 import android.content.Context
+import android.content.Intent
 import android.content.res.Resources
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.MenuItem
@@ -24,6 +26,7 @@ import com.absinthe.libchecker.database.LCDatabase
 import com.absinthe.libchecker.database.Repositories
 import com.absinthe.libchecker.database.backup.RoomBackup
 import com.absinthe.libchecker.databinding.ActivityBackupBinding
+import com.absinthe.libchecker.ui.main.MainActivity
 import com.absinthe.libchecker.utils.FileUtils
 import com.absinthe.libchecker.utils.LCAppUtils
 import com.absinthe.libchecker.utils.StorageUtils
@@ -61,6 +64,9 @@ class BackupActivity : BaseActivity<ActivityBackupBinding>() {
         .commit()
     }
     onBackPressedDispatcher.addCallback(this, true) {
+      if (intent?.data != null) {
+        startActivity(Intent(this@BackupActivity, MainActivity::class.java))
+      }
       finish()
     }
   }
@@ -109,55 +115,9 @@ class BackupActivity : BaseActivity<ActivityBackupBinding>() {
           }
         }
       restoreResultLauncher =
-        registerForActivityResult(ActivityResultContracts.GetContent()) {
-          it?.let {
-            activity?.let { activity ->
-              runCatching {
-                activity.contentResolver.openInputStream(it)
-                  ?.let { inputStream ->
-                    val dialog = LCAppUtils.createLoadingDialog(activity)
-                    dialog.show()
-                    if (it.toString().endsWith(".sqlite3")) {
-                      lifecycleScope.launch(Dispatchers.IO) {
-                        val restoreFile = File(activity.externalCacheDir, "restore.sqlite3")
-                        inputStream.source().buffer().use { source ->
-                          restoreFile.outputStream().sink().buffer().use { sink ->
-                            source.readAll(sink)
-                          }
-                        }
-                        roomBackup
-                          .database(LCDatabase.getDatabase(requireContext()))
-                          .enableLogDebug(true)
-                          .backupLocation(RoomBackup.BACKUP_FILE_LOCATION_CUSTOM_FILE)
-                          .backupLocationCustomFile(restoreFile)
-                          .apply {
-                            onCompleteListener { success, message, exitCode ->
-                              Timber.d("success: $success, message: $message, exitCode: $exitCode")
-                              if (success) {
-                                restoreFile.delete()
-                                Once.clearDone(OnceTag.FIRST_LAUNCH)
-                                ProcessPhoenix.triggerRebirth(LibCheckerApp.app)
-                              }
-                              lifecycleScope.launch(Dispatchers.Main) {
-                                dialog.dismiss()
-                              }
-                            }
-                          }
-                          .restore()
-                      }
-                    } else {
-                      viewModel.restore(inputStream) { success ->
-                        if (!success) {
-                          context.showToast("Backup file error")
-                        }
-                        dialog.dismiss()
-                      }
-                    }
-                  }
-              }.onFailure { t ->
-                Timber.e(t)
-              }
-            }
+        registerForActivityResult(ActivityResultContracts.GetContent()) { result ->
+          result?.let {
+            restoreDatabase(it)
           }
         }
       roomBackup = RoomBackup(context)
@@ -217,6 +177,12 @@ class BackupActivity : BaseActivity<ActivityBackupBinding>() {
           true
         }
       }
+
+      activity?.intent?.data?.let { uri ->
+        if (uri.scheme == "content" && uri.path?.endsWith(".lcss") == true) {
+          restoreDatabase(uri)
+        }
+      }
     }
 
     override fun onCreateRecyclerView(
@@ -247,6 +213,56 @@ class BackupActivity : BaseActivity<ActivityBackupBinding>() {
           }
         }
       return recyclerView
+    }
+
+    private fun restoreDatabase(uri: Uri) {
+      activity?.let { activity ->
+        runCatching {
+          activity.contentResolver.openInputStream(uri)
+            ?.let { inputStream ->
+              val dialog = LCAppUtils.createLoadingDialog(activity)
+              dialog.show()
+              if (uri.toString().endsWith(".sqlite3")) {
+                lifecycleScope.launch(Dispatchers.IO) {
+                  val restoreFile = File(activity.externalCacheDir, "restore.sqlite3")
+                  inputStream.source().buffer().use { source ->
+                    restoreFile.outputStream().sink().buffer().use { sink ->
+                      source.readAll(sink)
+                    }
+                  }
+                  roomBackup
+                    .database(LCDatabase.getDatabase(requireContext()))
+                    .enableLogDebug(true)
+                    .backupLocation(RoomBackup.BACKUP_FILE_LOCATION_CUSTOM_FILE)
+                    .backupLocationCustomFile(restoreFile)
+                    .apply {
+                      onCompleteListener { success, message, exitCode ->
+                        Timber.d("success: $success, message: $message, exitCode: $exitCode")
+                        if (success) {
+                          restoreFile.delete()
+                          Once.clearDone(OnceTag.FIRST_LAUNCH)
+                          ProcessPhoenix.triggerRebirth(LibCheckerApp.app)
+                        }
+                        lifecycleScope.launch(Dispatchers.Main) {
+                          dialog.dismiss()
+                        }
+                      }
+                    }
+                    .restore()
+                }
+              } else {
+                viewModel.restore(requireContext(), inputStream) { success ->
+                  if (!success) {
+                    context?.showToast("Backup file error")
+                  }
+                  dialog.dismiss()
+                }
+              }
+            }
+        }.onFailure { t ->
+          Timber.e(t)
+        }
+      }
     }
   }
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -181,6 +181,7 @@
   <string name="album_backup_summary">将所有快照备份</string>
   <string name="album_restore">恢复</string>
   <string name="album_restore_summary">从备份文件恢复快照</string>
+  <string name="album_restore_detail">%s : 共 %s 项\n</string>
   <string name="album_click_to_choose">点击选择</string>
   <string name="album_dialog_delete_snapshot_message">处理中…</string>
   <!--  Integration  -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,6 +196,7 @@
   <string name="album_backup_summary">Backup all snapshots</string>
   <string name="album_restore">Restore</string>
   <string name="album_restore_summary">Restore snapshots from backup file</string>
+  <string name="album_restore_detail">%s : %s items in total\n</string>
   <string name="album_click_to_choose">Click to Choose</string>
   <string name="album_dialog_delete_snapshot_message">Processing…</string>
 


### PR DESCRIPTION
- Allow `BackupActivity` to respond to `lcss` files
> Addition: When opening an `lcss` file from file manager, and returning from `BackupActivity`, `MainActivity` is now recreated instead of exiting directly.
- When inserting `SnapshotItem` and `TimestampItem`, use REPLACE instead of IGNORE if there are conflicting items. 
> P.S. Because there are different timestamps, the same app will have different `SnapshotItem`, so there is no need to worry about the data in another snapshot being overwritten.