### PR TITLE
Fix duplicate SnapshotItem in database

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/database/LCDao.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/database/LCDao.kt
@@ -80,6 +80,10 @@ interface LCDao {
   suspend fun delete(item: SnapshotItem)
 
   @Transaction
+  @Query("DELETE FROM snapshot_table WHERE id NOT IN (SELECT id FROM snapshot_table GROUP BY packageName, timeStamp, versionCode, lastUpdatedTime, packageSize)")
+  suspend fun deleteDuplicateSnapshotItems()
+
+  @Transaction
   @Query("DELETE FROM snapshot_table")
   fun deleteAllSnapshots()
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/database/LCRepository.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/database/LCRepository.kt
@@ -126,6 +126,11 @@ class LCRepository(private val lcDao: LCDao) {
     lcDao.update(item)
   }
 
+  suspend fun deleteDuplicateSnapshotItems() {
+    if (checkDatabaseStatus().not()) return
+    lcDao.deleteDuplicateSnapshotItems()
+  }
+
   fun deleteAllSnapshots() {
     if (checkDatabaseStatus().not()) return
     lcDao.deleteAllSnapshots()

--- a/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/SnapshotViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/SnapshotViewModel.kt
@@ -1301,6 +1301,7 @@ class SnapshotViewModel(application: Application) : AndroidViewModel(application
       }
 
       repository.insertSnapshots(finalList)
+      repository.deleteDuplicateSnapshotItems()
       finalList.clear()
       count = 0
       timeStampSet.forEach { insertTimeStamp(it) }


### PR DESCRIPTION
After the snapshot is restored, some snapshots may show that the number of snapshot applications is twice or even three times the actual number of applications. In this fix, the duplicated data will be cleaned up once after the snapshot restore is done.