### PR TITLE
Correct adv_mark_exported translation for Simpled Chinese

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -208,7 +208,7 @@
   <string name="adv_show_target_version">显示 Target 版本</string>
   <string name="adv_show_min_version">显示 Min 版本</string>
   <string name="adv_tint_abi_label">ABI 徽标染色</string>
-  <string name="adv_mark_exported">标记已导出的组件</string>
+  <string name="adv_mark_exported">标记对外暴露的组件</string>
   <string name="adv_mark_disabled">标记已禁用的组件</string>
   <string name="adv_show_marked_lib">显示已标记的库</string>
 </resources>


### PR DESCRIPTION
`android:exported` 应该是 “对外暴露的” 而不是 “已导出的”