### PR TITLE
Fix wrong tab in detail page

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/BaseAppDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/BaseAppDetailActivity.kt
@@ -615,7 +615,12 @@ abstract class BaseAppDetailActivity :
       viewModel.initAbilities(packageInfo.packageName)
     }
 
-    onPostPackageInfoAvailable()
+    // To ensure onPostPackageInfoAvailable() is executed at the end of ui thread
+    lifecycleScope.launch(Dispatchers.IO) {
+      withContext(Dispatchers.Main) {
+        onPostPackageInfoAvailable()
+      }
+    }
   }
 
   protected open fun onPostPackageInfoAvailable() {}


### PR DESCRIPTION
The past execution order of the main thread::
```kotlin
// block

onPostPackageInfoAvailable()

typeList.add(1, STATIC)
tabTitles.add(1, getText(R.string.ref_category_static))
binding.tabLayout.addTab(
  binding.tabLayout.newTab()
    .also { it.text = getText(R.string.ref_category_static) },
  1
)
onStaticLibsAvailable()
```

The current execution order of the main thread:
```kotlin
// block

typeList.add(1, STATIC)
tabTitles.add(1, getText(R.string.ref_category_static))
binding.tabLayout.addTab(
  binding.tabLayout.newTab()
    .also { it.text = getText(R.string.ref_category_static) },
  1
)
onStaticLibsAvailable()

onPostPackageInfoAvailable()
```

> Closes #703 