### PR TITLE
Fix crash when set view's tag

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/AppPropsAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/AppPropsAdapter.kt
@@ -81,11 +81,11 @@ class AppPropsAdapter(
 
     if (itemView.linkToIcon.isVisible) {
       itemView.linkToIcon.setOnClickListener {
-        val transformed = itemView.linkToIcon.getTag(item.value.toInt()) as? Boolean ?: false
+        val transformed = itemView.linkToIcon.tag as? Boolean? ?: false
         if (transformed) {
           itemView.value.text = parseValue(item)
           itemView.linkToIcon.setImageResource(R.drawable.ic_outline_change_circle_24)
-          itemView.linkToIcon.setTag(item.value.toInt(), false)
+          itemView.linkToIcon.tag = false
         } else {
           var clickedTag = false
           Timber.d("type: $type")
@@ -145,7 +145,7 @@ class AppPropsAdapter(
               }
             }
           }
-          itemView.linkToIcon.setTag(item.value.toInt(), clickedTag)
+          itemView.linkToIcon.tag = clickedTag
         }
       }
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/AppPropsAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/AppPropsAdapter.kt
@@ -81,11 +81,11 @@ class AppPropsAdapter(
 
     if (itemView.linkToIcon.isVisible) {
       itemView.linkToIcon.setOnClickListener {
-        val transformed = itemView.linkToIcon.tag as? Boolean? ?: false
+        val transformed = itemView.linkToIcon.getTag(R.id.resource_transformed_id) as? Boolean ?: false
         if (transformed) {
           itemView.value.text = parseValue(item)
           itemView.linkToIcon.setImageResource(R.drawable.ic_outline_change_circle_24)
-          itemView.linkToIcon.tag = false
+          itemView.linkToIcon.setTag(R.id.resource_transformed_id, false)
         } else {
           var clickedTag = false
           Timber.d("type: $type")
@@ -145,7 +145,7 @@ class AppPropsAdapter(
               }
             }
           }
-          itemView.linkToIcon.tag = clickedTag
+          itemView.linkToIcon.setTag(R.id.resource_transformed_id, clickedTag)
         }
       }
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/LibStringAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/LibStringAdapter.kt
@@ -269,12 +269,11 @@ class LibStringAdapter(
 
     if (itemView.linkToIcon.isVisible) {
       itemView.linkToIcon.setOnClickListener {
-        val transformed =
-          itemView.linkToIcon.getTag(item.item.size.toInt()) as? Boolean ?: false
+        val transformed = itemView.linkToIcon.tag as? Boolean ?: false
         if (transformed) {
           itemView.libSize.text = item.item.source
           itemView.linkToIcon.setImageResource(R.drawable.ic_outline_change_circle_24)
-          itemView.linkToIcon.setTag(item.item.size.toInt(), false)
+          itemView.linkToIcon.tag = false
         } else {
           var clickedTag = false
           item.item.source?.let {
@@ -352,7 +351,7 @@ class LibStringAdapter(
               }
             }
           }
-          itemView.linkToIcon.setTag(item.item.size.toInt(), clickedTag)
+          itemView.linkToIcon.tag = clickedTag
         }
       }
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/LibStringAdapter.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/recyclerview/adapter/detail/LibStringAdapter.kt
@@ -269,11 +269,11 @@ class LibStringAdapter(
 
     if (itemView.linkToIcon.isVisible) {
       itemView.linkToIcon.setOnClickListener {
-        val transformed = itemView.linkToIcon.tag as? Boolean ?: false
+        val transformed = itemView.linkToIcon.getTag(R.id.resource_transformed_id) as? Boolean ?: false
         if (transformed) {
           itemView.libSize.text = item.item.source
           itemView.linkToIcon.setImageResource(R.drawable.ic_outline_change_circle_24)
-          itemView.linkToIcon.tag = false
+          itemView.linkToIcon.setTag(R.id.resource_transformed_id, false)
         } else {
           var clickedTag = false
           item.item.source?.let {
@@ -351,7 +351,7 @@ class LibStringAdapter(
               }
             }
           }
-          itemView.linkToIcon.tag = clickedTag
+          itemView.linkToIcon.setTag(R.id.resource_transformed_id, clickedTag)
         }
       }
     }

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -9,4 +9,6 @@
   <item name="sort_by_target_version" type="id" />
 
   <item name="adapter_bottom_padding_id" type="id" />
+
+  <item name="resource_transformed_id" type="id" />
 </resources>


### PR DESCRIPTION
When setting some tags with a specific key, if the key is not the id in the app, for example, when converting resources of the Android system, it will cause IllegalArgumentException.

We can simply set the tag directly because the itemview is not shared, they are different instances, and the tag will not be shared.