### PR TITLE
Do not return early to detect latest rxjava version

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/PackageInfoExtensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/PackageInfoExtensions.kt
@@ -447,8 +447,7 @@ suspend fun PackageInfo.getRxJavaVersion(): String? = withContext(Dispatchers.IO
         "rx.*".toClassDefType(),
         "io.reactivex.*".toClassDefType(),
         "io.reactivex.rxjava3.*".toClassDefType()
-      ),
-      hasAny = false
+      )
     )
     if (resultList.contains("io.reactivex.rxjava3.*".toClassDefType())) {
       return@withContext RX_MAJOR_THREE

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/PackageInfoExtensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/PackageInfoExtensions.kt
@@ -511,8 +511,7 @@ suspend fun PackageInfo.getRxKotlinVersion(): String? = withContext(Dispatchers.
         "io.reactivex.rxjava3.kotlin.*".toClassDefType(),
         "io.reactivex.rxkotlin".toClassDefType(),
         "rx.lang.kotlin".toClassDefType()
-      ),
-      hasAny = true
+      )
     )
     if (resultList.contains("io.reactivex.rxjava3.kotlin.*".toClassDefType())) {
       return@withContext RX_MAJOR_THREE
@@ -555,8 +554,7 @@ suspend fun PackageInfo.getRxAndroidVersion(): String? = withContext(Dispatchers
       "io.reactivex.rxjava3.android.*".toClassDefType(),
       "io.reactivex.android.*".toClassDefType(),
       "rx.android.*".toClassDefType()
-    ),
-    hasAny = true
+    )
   )
   if (resultList.contains("io.reactivex.rxjava3.android.*".toClassDefType())) {
     return@withContext RX_MAJOR_THREE

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/PackageInfoExtensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/PackageInfoExtensions.kt
@@ -448,7 +448,7 @@ suspend fun PackageInfo.getRxJavaVersion(): String? = withContext(Dispatchers.IO
         "io.reactivex.*".toClassDefType(),
         "io.reactivex.rxjava3.*".toClassDefType()
       ),
-      hasAny = true
+      hasAny = false
     )
     if (resultList.contains("io.reactivex.rxjava3.*".toClassDefType())) {
       return@withContext RX_MAJOR_THREE


### PR DESCRIPTION
Previously the version check was always running into the early return condition for `findDexClasses` because `hasAny` was true.

This resulted in never reaching version 3 for RxJava.