### PR TITLE
Fix predictive back

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
     android:appCategory="productivity"
     android:configChanges="orientation"
     android:dataExtractionRules="@xml/data_extraction_rules"
-    android:enableOnBackInvokedCallback="true"
+    android:enableOnBackInvokedCallback="@bool/appOnBackInvokedCallbackEnabled"
     android:fullBackupContent="@xml/backup_rules"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/BackupActivity.kt
@@ -9,7 +9,6 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.activity.addCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
@@ -27,6 +26,7 @@ import com.absinthe.libchecker.database.backup.RoomBackup
 import com.absinthe.libchecker.databinding.ActivityBackupBinding
 import com.absinthe.libchecker.ui.base.BaseActivity
 import com.absinthe.libchecker.ui.main.MainActivity
+import com.absinthe.libchecker.ui.main.addBackStateHandler
 import com.absinthe.libchecker.utils.FileUtils
 import com.absinthe.libchecker.utils.StorageUtils
 import com.absinthe.libchecker.utils.UiUtils
@@ -63,12 +63,17 @@ class BackupActivity : BaseActivity<ActivityBackupBinding>() {
         .replace(R.id.fragment_container, BackupFragment())
         .commit()
     }
-    onBackPressedDispatcher.addCallback(this, true) {
-      if (intent?.data != null) {
-        startActivity(Intent(this@BackupActivity, MainActivity::class.java))
-      }
-      finish()
-    }
+    onBackPressedDispatcher.addBackStateHandler(
+      lifecycleOwner = this,
+      enabledState = { intent?.data != null },
+      handler = {
+        val intent = Intent(this, MainActivity::class.java)
+          // flags to bring MainActivity to the front and clear back stack
+          .setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        startActivity(intent)
+        finish()
+      },
+    )
   }
 
   override fun onApplyUserThemeResource(theme: Resources.Theme, isDecorView: Boolean) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/ComparisonActivity.kt
@@ -16,7 +16,6 @@ import android.view.Gravity
 import android.view.MenuItem
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.activity.addCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -119,9 +118,6 @@ class ComparisonActivity : BaseActivity<ActivityComparisonBinding>() {
   }
 
   private fun registerCallbacks() {
-    onBackPressedDispatcher.addCallback(this, true) {
-      finish()
-    }
     chooseApkResultLauncher =
       registerForActivityResult(ActivityResultContracts.GetContent()) {
         if (isLeftPartChoosing) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/album/TrackActivity.kt
@@ -10,7 +10,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Checkable
 import android.widget.FrameLayout
-import androidx.activity.addCallback
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle
@@ -50,9 +49,6 @@ class TrackActivity :
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     initView()
-    onBackPressedDispatcher.addCallback(this, true) {
-      finish()
-    }
   }
 
   private fun initView() {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/BaseAppDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/BaseAppDetailActivity.kt
@@ -13,7 +13,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -69,6 +68,7 @@ import com.absinthe.libchecker.ui.fragment.detail.impl.NativeAnalysisFragment
 import com.absinthe.libchecker.ui.fragment.detail.impl.PermissionAnalysisFragment
 import com.absinthe.libchecker.ui.fragment.detail.impl.SignaturesAnalysisFragment
 import com.absinthe.libchecker.ui.fragment.detail.impl.StaticAnalysisFragment
+import com.absinthe.libchecker.ui.main.addBackStateHandler
 import com.absinthe.libchecker.utils.FileUtils
 import com.absinthe.libchecker.utils.OsUtils
 import com.absinthe.libchecker.utils.PackageUtils
@@ -140,14 +140,11 @@ abstract class BaseAppDetailActivity :
       setDisplayHomeAsUpEnabled(true)
       setDisplayShowHomeEnabled(true)
     }
-    onBackPressedDispatcher.addCallback(this, true) {
-      val closeBtn = findViewById<View>(androidx.appcompat.R.id.search_close_btn)
-      if (closeBtn != null) {
-        binding.toolbar.collapseActionView()
-      } else {
-        finish()
-      }
-    }
+    onBackPressedDispatcher.addBackStateHandler(
+      enabledState = { binding.toolbar.hasExpandedActionView() },
+      handler = { binding.toolbar.collapseActionView() },
+      lifecycleOwner = this,
+    )
   }
 
   protected fun onPackageInfoAvailable(packageInfo: PackageInfo, extraBean: DetailExtraBean?) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/BackStateHandler.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/BackStateHandler.kt
@@ -1,0 +1,46 @@
+package com.absinthe.libchecker.ui.main
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.coroutineScope
+import androidx.lifecycle.flowWithLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
+
+inline fun OnBackPressedDispatcher.addBackStateHandler(
+  lifecycleOwner: LifecycleOwner,
+  crossinline enabledState: () -> Boolean,
+  crossinline handler: () -> Unit,
+) {
+  val backCallback = object : OnBackPressedCallback(false) {
+    override fun handleOnBackPressed() {
+      isEnabled = false
+      handler()
+    }
+  }
+  this.addCallback(lifecycleOwner, backCallback)
+  // update callback enabled state every 1s in the background
+  val expandStateFlow = flow {
+    while (true) {
+      emit(enabledState())
+      delay(1000)
+    }
+  }
+  val lifecycle = lifecycleOwner.lifecycle
+  expandStateFlow
+    .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+    .distinctUntilChanged()
+    .onEach { enabled -> backCallback.isEnabled = enabled }
+    .flowOn(Dispatchers.Default)
+    .onEach { enabled -> Timber.d("BackStateHandler/enabled:$enabled") }
+    .flowOn(Dispatchers.Main)
+    .launchIn(lifecycle.coroutineScope)
+}

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/ChartActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/ChartActivity.kt
@@ -3,7 +3,6 @@ package com.absinthe.libchecker.ui.main
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.ViewGroup
-import androidx.activity.addCallback
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.databinding.ActivityChartBinding
 import com.absinthe.libchecker.ui.base.BaseActivity
@@ -22,10 +21,6 @@ class ChartActivity : BaseActivity<ActivityChartBinding>() {
       supportFragmentManager.beginTransaction()
         .replace(R.id.fragment_container, ChartFragment())
         .commit()
-    }
-
-    onBackPressedDispatcher.addCallback(this, true) {
-      finish()
     }
   }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/main/MainActivity.kt
@@ -7,7 +7,6 @@ import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.IBinder
 import android.view.View
-import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.MenuProvider
@@ -15,8 +14,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
@@ -46,9 +43,6 @@ import com.microsoft.appcenter.analytics.EventProperties
 import jonathanfinerty.once.Once
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -237,27 +231,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), INavViewContainer, IAp
       }
     }
 
-    val backCallback = object : OnBackPressedCallback(false) {
-      override fun handleOnBackPressed() {
-        binding.toolbar.collapseActionView()
-      }
-    }
-    onBackPressedDispatcher.addCallback(this, backCallback)
-    // update callback enabled state every 1s in the background
-    val expandStateFlow = flow {
-      while (true) {
-        emit(binding.toolbar.hasExpandedActionView())
-        delay(1000)
-      }
-    }
-    expandStateFlow
-      .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
-      .onEach { expanded -> backCallback.isEnabled = expanded }
-      .flowOn(Dispatchers.Default)
-      .distinctUntilChanged()
-      .onEach { expanded -> Timber.d("main/expandedAction:$expanded") }
-      .flowOn(Dispatchers.Main)
-      .launchIn(lifecycleScope)
+    onBackPressedDispatcher.addBackStateHandler(
+      enabledState = { binding.toolbar.hasExpandedActionView() },
+      handler = { binding.toolbar.collapseActionView() },
+      lifecycleOwner = this,
+    )
   }
 
   /**

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/snapshot/AlbumActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.ContextThemeWrapper
 import android.view.MenuItem
 import android.view.ViewGroup
-import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
@@ -42,9 +41,6 @@ class AlbumActivity : BaseActivity<ActivityAlbumBinding>() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     initView()
-    onBackPressedDispatcher.addCallback(this, true) {
-      finish()
-    }
   }
 
   private fun initView() {

--- a/app/src/main/res/values-v34/values.xml
+++ b/app/src/main/res/values-v34/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="appOnBackInvokedCallbackEnabled">true</bool>
+</resources>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- disable OnBackInvokedCallback for Android 13 and below -->
+  <!-- for it causes flickering even with the developer option turned off (i.e. common user xp) -->
+  <bool name="appOnBackInvokedCallbackEnabled">false</bool>
+</resources>


### PR DESCRIPTION
关于 issue #495，当前的实现有两个问题：
1. 无条件启用OnBackPressedCallback，使得预测性返回动画失效
2. 调用finish()，根据安卓12的[新特性](https://developer.android.com/about/versions/12/behavior-changes-all#back-press)，不应该手动结束 launcher activity

我这里改动成了后台每秒检测搜索框的展开状态，然后更新`OnBackPressedCallback`的启用状态。

我看这个搜索的action view默认就支持返回的，如果是为了修复可能的bug，要么在展示/关闭搜索框action view的多个地方更新OnBackPressedCallback的启用状态，要么在`MainActivity`通过intercept某个action view的状态更新方法统一更新启用状态。
I tried to override `MenuHost.addMenuProvider(MenuProvider)` in `MainActivity`, create our `MenuProviderDelegate` class to wrap the menuProvider argument, and intercept `MenuProvider.onMenuItemSelected()` to update `OnBackPressedCallback` enabled state. However this approach changes the menuProvider object reference to our delegate/wrapper, and makes menuProvider management more complex. So finally I settled with an easier polling approach. Of course a better approach would work more efficiently.