### PR TITLE
Add a tracker for applist large diff

### DIFF
--- a/app/src/foss/kotlin/com/absinthe/libchecker/dev/exception/AppListIncompleteException.kt
+++ b/app/src/foss/kotlin/com/absinthe/libchecker/dev/exception/AppListIncompleteException.kt
@@ -1,0 +1,12 @@
+package com.absinthe.libchecker.dev.exception
+
+class AppListIncompleteException(message: String?) : Exception(message) {
+  companion object {
+    fun toggleAndSubmit(
+      appList: Collection<String>,
+      newApps: Collection<String>,
+      deletedApps: Collection<String>
+    ) {
+    }
+  }
+}

--- a/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/viewmodel/HomeViewModel.kt
@@ -32,6 +32,7 @@ import com.absinthe.libchecker.constant.OnceTag
 import com.absinthe.libchecker.data.app.LocalAppDataSource
 import com.absinthe.libchecker.database.Repositories
 import com.absinthe.libchecker.database.entity.LCItem
+import com.absinthe.libchecker.dev.exception.AppListIncompleteException
 import com.absinthe.libchecker.model.LibChip
 import com.absinthe.libchecker.model.LibReference
 import com.absinthe.libchecker.model.LibStringItem
@@ -228,6 +229,7 @@ class HomeViewModel : ViewModel() {
        */
       if (!checked && (newApps.size > 30 || removedApps.size > 30)) {
         Timber.w("Request change canceled because of large diff, re-request appMap")
+        AppListIncompleteException.toggleAndSubmit(localApps, newApps, removedApps)
         launch {
           requestChange(true)
         }

--- a/app/src/market/kotlin/com/absinthe/libchecker/dev/exception/AppListIncompleteException.kt
+++ b/app/src/market/kotlin/com/absinthe/libchecker/dev/exception/AppListIncompleteException.kt
@@ -1,0 +1,29 @@
+package com.absinthe.libchecker.dev.exception
+
+import com.absinthe.libchecker.BuildConfig
+
+class AppListIncompleteException(message: String?) : Exception(message) {
+  companion object {
+    fun toggleAndSubmit(
+      appList: Collection<String>,
+      newApps: Collection<String>,
+      deletedApps: Collection<String>
+    ) {
+      if (BuildConfig.IS_DEV_VERSION.not()) return
+      runCatching {
+        val msg = buildString {
+          append("Large diff detected in app list. ")
+          appendLine()
+          append("Total: ${appList.size}")
+          appendLine()
+          append("New: ${newApps.size}")
+          appendLine()
+          append("Deleted: ${deletedApps.size}")
+          appendLine()
+          append("Same: ${newApps.filter { deletedApps.contains(it) }.size}")
+        }
+        throw AppListIncompleteException(msg)
+      }
+    }
+  }
+}


### PR DESCRIPTION
In order to better fix the problem of large differences in app list, we have introduced a new Exception to track the problem. We only collect the total number of your apps, as well as the total number of new and deleted apps exported internally, and no other information will be collected.

This tracker will be removed when a new version is released.