### PR TITLE
Fix the problem of failing to parse APKs with `minSdkVersion` higher …

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/LibCheckerApp.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/LibCheckerApp.kt
@@ -3,6 +3,7 @@ package com.absinthe.libchecker
 import android.app.Application
 import android.content.Context
 import android.content.pm.PackageManager
+import android.content.pm.PackageParser
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.window.embedding.RuleController
 import androidx.window.embedding.SplitController
@@ -47,6 +48,7 @@ class LibCheckerApp : Application() {
     if (OsUtils.atLeastP()) {
       HiddenApiBypass.addHiddenApiExemptions("")
     }
+    bypassPackageParserCheck()
 
     app = this
     if (!BuildConfig.DEBUG && GlobalValues.isAnonymousAnalyticsEnabled.value == true) {
@@ -113,6 +115,16 @@ class LibCheckerApp : Application() {
           }
         )
       }
+    }
+  }
+
+  private fun bypassPackageParserCheck() {
+    // bypass PackageParser check
+    // see also: https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/content/pm/PackageParser.java;l=2695
+    @Suppress("SoonBlockedPrivateApi")
+    PackageParser::class.java.getDeclaredField("SDK_VERSION").apply {
+      isAccessible = true
+      set(null, Integer.MAX_VALUE)
     }
   }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/detail/ApkDetailActivity.kt
@@ -2,9 +2,7 @@ package com.absinthe.libchecker.ui.detail
 
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.content.pm.PackageParser
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import androidx.lifecycle.lifecycleScope
@@ -111,30 +109,7 @@ class ApkDetailActivity : BaseAppDetailActivity(), IDetailContainer {
                   onPackageInfoAvailable(pi, null)
                   dialog.dismiss()
                 } ?: run {
-                  Timber.d("PackageParser sdk version=${PackageParser.SDK_VERSION}")
-                  // bypass PackageParser check
-                  // see also: https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/content/pm/PackageParser.java;l=2695
-                  @Suppress("SoonBlockedPrivateApi")
-                  PackageParser::class.java.getDeclaredField("SDK_VERSION").apply {
-                    isAccessible = true
-                    set(null, Integer.MAX_VALUE)
-                  }
-
-                  PackageManagerCompat.getPackageArchiveInfo(tf.path, flag)?.also {
-                    it.applicationInfo.sourceDir = tf.path
-                    it.applicationInfo.publicSourceDir = tf.path
-                  }?.let { pi ->
-                    onPackageInfoAvailable(pi, null)
-                    dialog.dismiss()
-                  } ?: run {
-                    finish()
-                  }
-
-                  @Suppress("SoonBlockedPrivateApi")
-                  PackageParser::class.java.getDeclaredField("SDK_VERSION").apply {
-                    set(null, Build.VERSION.SDK_INT)
-                    isAccessible = false
-                  }
+                  finish()
                 }
               }
             } else {

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/Toasty.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/Toasty.kt
@@ -11,6 +11,7 @@ import androidx.annotation.MainThread
 import androidx.annotation.StringRes
 import com.absinthe.libchecker.view.app.ToastView
 import java.lang.ref.WeakReference
+import timber.log.Timber
 
 /**
  * <pre>
@@ -81,6 +82,7 @@ fun Context.showToast(message: String) {
 
 @AnyThread
 fun Context.showToast(@StringRes res: Int) {
+  Timber.d("showToast: ${getString(res)}")
   Toasty.showShort(this, res)
 }
 


### PR DESCRIPTION
…than the device for the first time.

Due to Java compiler inline optimizations, it may fail the first time, maybe we should do bypassing logic at app startup.