### PR TITLE
Avoid add same menu provider

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/features/settings/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/settings/ui/SettingsFragment.kt
@@ -335,10 +335,6 @@ class SettingsFragment : PreferenceFragmentCompat(), IListController {
     val container = (activity as? IAppBarContainer) ?: return
     if (this != viewModel.controller) {
       viewModel.controller = this
-      container.currentMenuProvider?.let { current ->
-        activity?.removeMenuProvider(current)
-      }
-      container.currentMenuProvider = null
     }
     scheduleAppbarRaisingStatus(!getBorderViewDelegate().isShowingTopBorder)
     container.setLiftOnScrollTargetView(prefRecyclerView)

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/base/IAppBarContainer.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/base/IAppBarContainer.kt
@@ -1,10 +1,8 @@
 package com.absinthe.libchecker.ui.base
 
 import android.view.View
-import androidx.core.view.MenuProvider
 
 interface IAppBarContainer {
-  var currentMenuProvider: MenuProvider?
   fun scheduleAppbarLiftingStatus(isLifted: Boolean)
   fun setLiftOnScrollTargetView(targetView: View)
 }


### PR DESCRIPTION
After binding menu provider with lifecycle state, we don't need extra check when removing menu provider.