### PR TITLE
Fix bug and add unity check

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: macos-latest-xlarge
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
@@ -584,7 +584,7 @@ class HomeViewModel : ViewModel() {
       if (referenceMap[it.name] == null) {
         referenceMap[it.name] = mutableSetOf<String>() to NATIVE
       }
-      if (LCAppUtils.checkNativeLibValidation(packageName, it.name)) {
+      if (LCAppUtils.checkNativeLibValidation(packageName, it.name, list)) {
         referenceMap[it.name]!!.first.add(packageName)
       }
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/LCAppUtils.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/LCAppUtils.kt
@@ -124,7 +124,7 @@ object LCAppUtils {
         }.getOrDefault(false)
       }
       "libmain.so" -> {
-         runCatching {
+        runCatching {
           otherNativeLibs?.any { it.name == "libunity.so" } == true
         }.getOrDefault(false)
       }

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/LCAppUtils.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/LCAppUtils.kt
@@ -82,7 +82,7 @@ object LCAppUtils {
   }
 
   private val checkNativeLibs =
-    listOf("libjiagu.so", "libjiagu_a64.so", "libjiagu_x86.so", "libjiagu_x64.so", "libDexHelper.so", "libDexHelper-x86.so", "libdexjni.so", "libapp.so")
+    listOf("libjiagu.so", "libjiagu_a64.so", "libjiagu_x86.so", "libjiagu_x64.so", "libDexHelper.so", "libDexHelper-x86.so", "libdexjni.so", "libapp.so", "libmain.so")
   fun checkNativeLibValidation(
     packageName: String,
     nativeLib: String,
@@ -121,6 +121,11 @@ object LCAppUtils {
               "io.flutter.FlutterInjector".toClassDefType()
             )
           ).any { it == "io.flutter.FlutterInjector".toClassDefType() }
+        }.getOrDefault(false)
+      }
+      "libmain.so" -> {
+         runCatching {
+          otherNativeLibs?.any { it.name == "libunity.so" } == true
         }.getOrDefault(false)
       }
       else -> true


### PR DESCRIPTION
Fix wrong exclusion when apps meet the rules for native libraries (e.g. an app that uses Flutter has both `libapp.so` and `libflutter.so` native libraries, but no `io.flutter.FlutterInjector` class).
Some apps, such as Music Tag (com.xjcheng.musictageditor), that don't use unity but have `libmain.so` should be excluded.