### PR TITLE
Always convert hex strings to uppercase

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/MessageDigestExtensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/MessageDigestExtensions.kt
@@ -13,7 +13,7 @@ fun ByteArray.md5(separator: CharSequence = ""): String = toByteString().md5().t
 
 fun ByteArray.toHexString(separator: CharSequence = ""): String = joinToString(separator) {
   it.toInt().and(0xff).toString(16).padStart(2, '0')
-}
+}.uppercase()
 
 fun File.md5(): String = readBytes().md5()
 


### PR DESCRIPTION
Resolves #1217 

We can debate whether it's best to use UPPERCASE "from the get-go", in `MessageDigestExtensions` how I implemented it now or only do the conversion e.g. at `PackageUtils`, and whether we should do it for all hex values or just signature hashes, which my referenced issue is about.