### PR TITLE
Fix an issue that causes processBar not disappear in permission fragment when processesMap is empty

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/features/applist/detail/ui/BaseAppDetailActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/applist/detail/ui/BaseAppDetailActivity.kt
@@ -536,7 +536,6 @@ abstract class BaseAppDetailActivity :
         }
       }.launchIn(lifecycleScope)
       it.processMapStateFlow.onEach { map ->
-        if (map.isEmpty()) return@onEach
         if (processBarView == null) {
           initProcessBarView()
         }


### PR DESCRIPTION
Fix an issue that causes processBar not disappear in permission fragment when processesMap is empty