### PR TITLE
fix: appname width for SnapshotTitleView

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/features/snapshot/detail/ui/view/SnapshotTitleView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/snapshot/detail/ui/view/SnapshotTitleView.kt
@@ -172,7 +172,7 @@ class SnapshotTitleView(
       measuredWidth - paddingStart - paddingEnd - iconView.measuredWidth - appNameView.marginStart
     if (appNameView.measuredWidth > textWidth) {
       appNameView.measure(
-        (textWidth - apisView.measuredWidth - appNameView.marginEnd).toExactlyMeasureSpec(),
+        textWidth.toExactlyMeasureSpec(),
         appNameView.defaultHeightMeasureSpec(this)
       )
     }


### PR DESCRIPTION
should not minus apisView's width, and marginEnd is zero

before
![1](https://github.com/user-attachments/assets/98807dd1-c2f6-47d7-9473-72e9a9afcf11)
after
![2](https://github.com/user-attachments/assets/d07e935f-48bb-4b5c-859b-12a1a2dfac3e)
