### PR TITLE
refactor: Remove old "Show System Apps" option

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/constant/Constants.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/constant/Constants.kt
@@ -40,7 +40,6 @@ object Constants {
   const val EXAMPLE_DISABLED = "this.is.disabled"
   const val EXAMPLE_RULE = "Example SDK"
 
-  const val PREF_SHOW_SYSTEM_APPS = "showSystemApps"
   const val PREF_APK_ANALYTICS = "apkAnalytics"
   const val PREF_RULES_REPO = "rulesRepository"
   const val PREF_COLORFUL_ICON = "colorfulIcon"

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/chart/ui/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/chart/ui/ChartFragment.kt
@@ -13,7 +13,6 @@ import com.absinthe.libchecker.R
 import com.absinthe.libchecker.api.ApiManager
 import com.absinthe.libchecker.compat.VersionCompat
 import com.absinthe.libchecker.constant.AndroidVersions
-import com.absinthe.libchecker.constant.Constants
 import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.database.Repositories
 import com.absinthe.libchecker.database.entity.LCItem
@@ -55,7 +54,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/chart/ui/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/chart/ui/ChartFragment.kt
@@ -182,12 +182,6 @@ class ChartFragment :
         }
       }
     }
-
-    GlobalValues.preferencesFlow.onEach {
-      if (it.first == Constants.PREF_SHOW_SYSTEM_APPS) {
-        setData(allLCItemsStateFlow.value)
-      }
-    }.launchIn(lifecycleScope)
   }
 
   private fun setData(items: List<LCItem>, chartType: ChartType = currentChartType) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/settings/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/settings/ui/SettingsFragment.kt
@@ -66,16 +66,6 @@ class SettingsFragment :
   override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
     setPreferencesFromResource(R.xml.settings, null)
 
-    findPreference<TwoStatePreference>(Constants.PREF_SHOW_SYSTEM_APPS)?.apply {
-      setOnPreferenceChangeListener { pref, newValue ->
-        emitPrefChange(pref.key, newValue)
-        Analytics.trackEvent(
-          Constants.Event.SETTINGS,
-          EventProperties().set("PREF_SHOW_SYSTEM_APPS", newValue as Boolean)
-        )
-        true
-      }
-    }
     findPreference<TwoStatePreference>(Constants.PREF_APK_ANALYTICS)?.apply {
       setOnPreferenceChangeListener { _, newValue ->
         val flag = if (newValue as Boolean) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/snapshot/detail/ui/view/SnapshotTitleView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/snapshot/detail/ui/view/SnapshotTitleView.kt
@@ -11,7 +11,6 @@ import androidx.core.text.buildSpannedString
 import androidx.core.text.scale
 import androidx.core.view.children
 import androidx.core.view.isVisible
-import androidx.core.view.marginEnd
 import androidx.core.view.marginStart
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.features.snapshot.detail.bean.SnapshotDiffItem


### PR DESCRIPTION
This commit removes the "Show System Apps" option from the settings and updates related code accordingly.