### PR TITLE
Fix Menu State Persistence Issue with Bottom Navigation

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
@@ -87,6 +87,10 @@ class HomeViewModel : ViewModel() {
   var appListStatus: Int = STATUS_NOT_START
   var workerBinder: IWorkerService? = null
 
+  // Simple menu state management
+  var isSearchMenuExpanded: Boolean = false
+  var currentSearchQuery: String = ""
+
   fun reloadApps() {
     if (appListStatus != STATUS_NOT_START || (initJob?.isActive == false && requestChangeJob?.isActive == false)) {
       Timber.d("reloadApps: ignore, appListStatus: $appListStatus")
@@ -741,5 +745,10 @@ class HomeViewModel : ViewModel() {
         }
       }
     }
+  }
+
+  fun clearMenuState() {
+    isSearchMenuExpanded = false
+    currentSearchQuery = ""
   }
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
@@ -6,7 +6,6 @@ import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.IBinder
 import android.view.Menu
-import android.view.MenuItem
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.widget.SearchView

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
@@ -416,5 +416,4 @@ class MainActivity :
       }
     }
   }
-
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
@@ -5,8 +5,11 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.IBinder
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import androidx.activity.viewModels
+import androidx.appcompat.widget.SearchView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
@@ -127,6 +130,32 @@ class MainActivity :
     unbindService(workerServiceConnection)
   }
 
+  override fun onPause() {
+    super.onPause()
+    saveToolbarMenuState()
+  }
+
+  private fun saveToolbarMenuState() {
+    if (!isBindingInitialized()) {
+      return
+    }
+    if (binding.toolbar.hasExpandedActionView()) {
+      binding.toolbar.menu?.findItem(R.id.search)?.let { searchItem ->
+        val searchView = searchItem.actionView as? SearchView
+        searchView?.let {
+          if (searchItem.isActionViewExpanded) {
+            appViewModel.isSearchMenuExpanded = true
+            it.query?.toString()?.let { query ->
+              appViewModel.currentSearchQuery = query
+            }
+          }
+        }
+      }
+    } else {
+      appViewModel.isSearchMenuExpanded = false
+    }
+  }
+
   override fun addMenuProvider(provider: MenuProvider) {
     if (_menuProviders.contains(provider)) {
       super.removeMenuProvider(provider)
@@ -218,6 +247,7 @@ class MainActivity :
           override fun onPageSelected(position: Int) {
             super.onPageSelected(position)
             navView.menu[position].isChecked = true
+            appViewModel.clearMenuState()
           }
         })
 
@@ -360,4 +390,32 @@ class MainActivity :
       }
     }
   }
+
+  override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
+    val result = super.onPrepareOptionsMenu(menu)
+    restoreToolbarMenuState()
+    return result
+  }
+
+  private fun restoreToolbarMenuState() {
+    if (!isBindingInitialized()) {
+      return
+    }
+    // Only restore state if menu exists and has search item
+    binding.toolbar.post {
+      val searchItem = binding.toolbar.menu?.findItem(R.id.search)
+      if (appViewModel.isSearchMenuExpanded) {
+        val searchView = searchItem?.actionView as? SearchView
+        searchView?.let {
+          if (!searchItem.isActionViewExpanded) {
+            searchItem.expandActionView()
+            if (appViewModel.currentSearchQuery.isNotEmpty()) {
+              it.setQuery(appViewModel.currentSearchQuery, false)
+            }
+          }
+        }
+      }
+    }
+  }
+
 }

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/base/BaseActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/base/BaseActivity.kt
@@ -72,4 +72,8 @@ abstract class BaseActivity<VB : ViewBinding> :
     theme.applyStyle(R.style.ThemeOverlay, true)
     theme.applyStyle(rikka.material.preference.R.style.ThemeOverlay_Rikka_Material3_Preference, true)
   }
+
+  protected fun isBindingInitialized(): Boolean {
+    return ::binding.isInitialized
+  }
 }


### PR DESCRIPTION
Fix Issue #1602 
When the app enters the background, the search menu's expanded state (SearchView) is lost due to Android's MenuHostHelper automatically invalidating menus when the activity lifecycle changed. This causes:

SearchView to collapse unexpectedly when returning from background
Loss of search query text

Solution: store and restore the menu state properly if current search item is expanded.
