### PR TITLE
Update library versions in libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 agp = "8.10.1"
-aboutlibraries = "12.2.2"
+aboutlibraries = "12.2.3"
 androidX-lifecycle = "2.9.1"
-androidX-room = "2.7.1"
+androidX-room = "2.7.2"
 firebase-bom = "33.10.0"
 hiddenApiRefine = "4.4.0"
 kotlin = "2.1.21"
 protoc = "4.31.1"
 shizuku = "13.1.5"
-square-retrofit = "2.12.0"
+square-retrofit = "3.0.0"
 zhaobozhen = "1.1.6"
 
 [plugins]
@@ -91,7 +91,7 @@ firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 flexbox = "com.google.android.flexbox:flexbox:3.0.0"
 hiddenApiBypass = "org.lsposed.hiddenapibypass:hiddenapibypass:6.1"
 lc-rules = "com.github.LibChecker:LibChecker-Rules-Bundle:40.2"
-lottie = "com.airbnb.android:lottie:6.6.6"
+lottie = "com.airbnb.android:lottie:6.6.7"
 mpAndroidChart = "com.github.AppDevNext:AndroidChart:3.1.0.27"
 once = "com.jonathanfinerty.once:once:1.3.1"
 processPhoenix = "com.jakewharton:process-phoenix:3.0.0"


### PR DESCRIPTION
Bump versions for aboutlibraries (12.2.3), androidX-room (2.7.2), square-retrofit (3.0.0), and lottie (6.6.7) to keep dependencies up to date.