### PR TITLE
Handle GET_INSTALLED_APPS permission workflow

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/constant/Constants.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/constant/Constants.kt
@@ -108,6 +108,8 @@ object Constants {
   const val PREF_RULE_LANGUAGE = "ruleLanguage"
   const val PREF_SNAPSHOT_AUTO_REMOVE_THRESHOLD = "snapshotAutoRemoveThreshold"
 
+  const val GET_INSTALLED_APPS = "com.android.permission.GET_INSTALLED_APPS"
+
   object Event {
     const val APP_INFO_BOTTOM_SHEET = "App Info Bottom Sheet"
     const val APP_LIST_ADVANCED_MENU_ITEM_CHANGED = "App List Advanced Menu Item Changed"

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
@@ -88,6 +88,7 @@ class HomeViewModel : ViewModel() {
   var controller: IListController? = null
   var appListStatus: Int = STATUS_NOT_START
   var workerBinder: IWorkerService? = null
+  var checkPackagesPermission: Boolean = false
 
   // Simple menu state management
   var isSearchMenuExpanded: Boolean = false

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/ui/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.absinthe.libchecker.features.home.ui
 
+import android.Manifest
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.IBinder
 import android.view.Menu
@@ -10,6 +12,7 @@ import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.widget.SearchView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -306,6 +309,21 @@ class MainActivity :
       enabledState = { !isKeyboardShowing() && binding.toolbar.hasExpandedActionView() },
       handler = { binding.toolbar.collapseActionView() }
     )
+  }
+
+  override fun onResume() {
+    super.onResume()
+    if (appViewModel.checkPackagesPermission) {
+      val granted =
+        ContextCompat.checkSelfPermission(
+          this,
+          Constants.GET_INSTALLED_APPS
+        ) == PackageManager.PERMISSION_GRANTED
+      if (granted) {
+        appViewModel.checkPackagesPermission = false
+        appViewModel.initItems()
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Process for obtaining the ‘Read list of installed applications’ (GET_INSTALLED_APPS) permission as required by China's Ministry of Industry and Information Technology
1. When the permission has not been granted, request it upon clicking the reject_view button
2. When the permission has not been granted, if the user navigates to the settings page to grant permission and then returns to the app, the app does not continue the process. Instead, upon returning to the app, it checks whether the permission exists; if so, it proceeds with the application list reading process

https://github.com/user-attachments/assets/5b1525ca-dad7-4a46-8802-3d82adb72b80

https://github.com/user-attachments/assets/71152255-d7a7-437e-b80f-aa00b9fe654c

---

处理国内工信部要求的"读取已安装应用列表"(GET_INSTALLED_APPS)权限获取流程
1. 未获取权限的情况下，点击reject_view时申请该权限
2. 未获取权限的情况下，用户前往设置页面允许权限后再返回app，此时app没有继续流程，改成返回app后判断到权限存在的话继续读取应用列表流程






