### PR TITLE
Update split apk regex.

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/PackageUtils.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/PackageUtils.kt
@@ -284,7 +284,7 @@ object PackageUtils {
     return map
   }
 
-  private val regex_splits by lazy { Regex("split_(delivery|config)\\.?(.*)\\.apk") }
+  private val regex_splits by lazy { Regex("split_(.*)\\.apk") }
 
   /**
    * Get split apks dirs


### PR DESCRIPTION
放宽正则范围，让支付宝、淘宝等软件正常显示
![Screenshot_2026-01-28-11-42-25-14_708f76cdf2c7449ff16a8486e0e036f6](https://github.com/user-attachments/assets/5860e2ec-0390-4aeb-b98d-dff5587503ba)
