### PR TITLE
feat: Support Xposed API 100

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/features/applist/detail/ui/XposedInfoDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/applist/detail/ui/XposedInfoDialogFragment.kt
@@ -67,61 +67,174 @@ class XposedInfoDialogFragment : BaseBottomSheetViewDialogFragment<XposedInfoBot
       val list = mutableListOf<XposedDetailItem>()
 
       ZipFileCompat(pi.applicationInfo!!.sourceDir).use { zipFile ->
+        // --- Load Modern Config (module.prop) ---
         val moduleProp = zipFile.getEntry("META-INF/xposed/module.prop")?.let { entry ->
           Properties().apply {
             load(zipFile.getInputStream(entry))
           }
         }
+        // --- Min API Version ---
+        // Doc: "minApiVersion (int) - Indicates the minimal Xposed API version"
+        // Fallback: legacy xposedMinVersion (prop) -> legacy meta-data
+        val minVersions = mutableListOf<Int>()
 
-        val minVersion = moduleProp?.getProperty("xposedMinVersion")
-          ?: metadataBundle["xposedminversion"]?.source.toString()
-        list.add(
-          XposedDetailItem(
-            iconRes = R.drawable.ic_app_prop,
-            tip = context.getString(R.string.lib_detail_xposed_min_version),
-            text = minVersion,
-            textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
+        moduleProp?.getProperty("minApiVersion")?.toIntOrNull()?.let {
+          minVersions.add(it)
+        }
+        moduleProp?.getProperty("xposedMinVersion")?.toIntOrNull()?.let {
+          minVersions.add(it)
+        }
+        metadataBundle["xposedminversion"]?.source?.toIntOrNull()?.let {
+          minVersions.add(it)
+        }
+
+        val finalMinVersion = minVersions.minOrNull()?.toString()
+
+        if (!finalMinVersion.isNullOrBlank()) {
+          list.add(
+            XposedDetailItem(
+              iconRes = R.drawable.ic_app_prop,
+              tip = context.getString(R.string.lib_detail_xposed_min_version),
+              text = finalMinVersion,
+              textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
+            )
           )
-        )
+        }
 
-        metadataBundle["xposedscope"]?.let { scopeItem ->
-          val appRes = SystemServices.packageManager.getResourcesForApplication(packageName)
-          runCatching {
-            appRes.getStringArray(scopeItem.size.toInt()).contentToString()
-          }.getOrNull()?.let { content ->
+        // --- Target API Version ---
+        // Doc: "targetApiVersion (int) - Indicates the target Xposed API version"
+        val targetVersion = moduleProp?.getProperty("targetApiVersion")
+        if (!targetVersion.isNullOrBlank()) {
+          list.add(
+            XposedDetailItem(
+              iconRes = R.drawable.ic_app_prop,
+              tip = context.getString(R.string.lib_detail_xposed_target_version),
+              text = targetVersion,
+              textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
+            )
+          )
+        }
+
+        // --- Static Scope (New in Modern API) ---
+        // Doc: "staticScope (boolean) - Indicates whether users should not apply the module on any other app out of scope"
+        val staticScope = moduleProp?.getProperty("staticScope")
+        if (staticScope == "true") {
+          list.add(
+            XposedDetailItem(
+              iconRes = R.drawable.ic_app_prop,
+              tip = context.getString(R.string.lib_detail_xposed_static_scope),
+              text = "True",
+              textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
+            )
+          )
+        }
+
+        // --- Scope List ---
+        // Doc: "scope list uses META-INF/xposed/scope.list (one line for one package name)"
+        val scopeListEntry = zipFile.getEntry("META-INF/xposed/scope.list")
+        if (scopeListEntry != null) {
+          val scopes = zipFile.getInputStream(scopeListEntry).bufferedReader().readLines()
+            .filter { it.isNotBlank() }
+
+          if (scopes.isNotEmpty()) {
             list.add(
               XposedDetailItem(
                 iconRes = R.drawable.ic_app_prop,
                 tip = context.getString(R.string.lib_detail_xposed_default_scope),
-                text = content,
+                text = scopes.joinToString("\n"),
+                textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
+              )
+            )
+          }
+        } else {
+          // Legacy: Metadata resource array
+          metadataBundle["xposedscope"]?.let { scopeItem ->
+            val appRes = SystemServices.packageManager.getResourcesForApplication(packageName)
+            runCatching {
+              appRes.getStringArray(scopeItem.size.toInt()).contentToString()
+            }.getOrNull()?.let { content ->
+              list.add(
+                XposedDetailItem(
+                  iconRes = R.drawable.ic_app_prop,
+                  tip = context.getString(R.string.lib_detail_xposed_default_scope),
+                  text = content,
+                  textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
+                )
+              )
+            }
+          }
+        }
+
+        // --- Entry Points ---
+        // Doc: "Java entry now uses META-INF/xposed/java_init.list"
+        zipFile.getEntry("META-INF/xposed/java_init.list")?.let { entry ->
+          val classes = zipFile.getInputStream(entry).bufferedReader().readLines()
+            .filter { it.isNotBlank() }
+            .joinToString("\n")
+          if (classes.isNotBlank()) {
+            list.add(
+              XposedDetailItem(
+                iconRes = R.drawable.ic_app_prop,
+                tip = context.getString(R.string.lib_detail_xposed_init_class) + " (Java)",
+                text = classes,
                 textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
               )
             )
           }
         }
 
+        // Doc: "native entry now uses META-INF/xposed/native_init.list"
+        zipFile.getEntry("META-INF/xposed/native_init.list")?.let { entry ->
+          val libs = zipFile.getInputStream(entry).bufferedReader().readLines()
+            .filter { it.isNotBlank() }
+            .joinToString("\n")
+          if (libs.isNotBlank()) {
+            list.add(
+              XposedDetailItem(
+                iconRes = R.drawable.ic_app_prop,
+                tip = context.getString(R.string.lib_detail_xposed_init_class) + " (Native)",
+                text = libs,
+                textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
+              )
+            )
+          }
+        }
+
+        // Legacy: assets/xposed_init
         zipFile.getEntry("assets/xposed_init")?.let { entry ->
           val cls = zipFile.getInputStream(entry).bufferedReader().readLines().firstOrNull()
+          if (!cls.isNullOrBlank()) {
+            list.add(
+              XposedDetailItem(
+                iconRes = R.drawable.ic_app_prop,
+                tip = context.getString(R.string.lib_detail_xposed_init_class) + " (Legacy)",
+                text = cls,
+                textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
+              )
+            )
+          }
+        }
+
+        // --- Description ---
+        // Doc: "module description uses the android:description resource"
+        // Fallback: module.prop description -> metadata xposeddescription
+        val description = if (pi.applicationInfo?.descriptionRes != 0) {
+          pi.applicationInfo?.loadDescription(SystemServices.packageManager)?.toString()
+        } else {
+          null
+        } ?: moduleProp?.getProperty("description")
+        ?: metadataBundle["xposeddescription"]?.source.toString()
+
+        if (description.isNotBlank() && description != "null") {
           list.add(
             XposedDetailItem(
-              iconRes = R.drawable.ic_app_prop,
-              tip = context.getString(R.string.lib_detail_xposed_init_class),
-              text = cls.toString(),
-              textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceSubtitle2)
+              iconRes = R.drawable.ic_content,
+              tip = context.getString(R.string.lib_detail_description_tip),
+              text = description,
+              textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceBody2)
             )
           )
         }
-
-        val description = moduleProp?.getProperty("description")
-          ?: metadataBundle["xposeddescription"]?.source.toString()
-        list.add(
-          XposedDetailItem(
-            iconRes = R.drawable.ic_content,
-            tip = context.getString(R.string.lib_detail_description_tip),
-            text = description,
-            textStyleRes = context.getResourceIdByAttr(com.google.android.material.R.attr.textAppearanceBody2)
-          )
-        )
       }
       contentAdapter.setList(list)
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/applist/detail/ui/XposedInfoDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/applist/detail/ui/XposedInfoDialogFragment.kt
@@ -223,7 +223,7 @@ class XposedInfoDialogFragment : BaseBottomSheetViewDialogFragment<XposedInfoBot
         } else {
           null
         } ?: moduleProp?.getProperty("description")
-        ?: metadataBundle["xposeddescription"]?.source.toString()
+          ?: metadataBundle["xposeddescription"]?.source.toString()
 
         if (description.isNotBlank() && description != "null") {
           list.add(

--- a/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/PackageInfoExtensions.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/utils/extensions/PackageInfoExtensions.kt
@@ -260,8 +260,16 @@ fun PackageInfo.getPackageSize(includeSplits: Boolean): Long {
  * @return True if is a Xposed module
  */
 fun PackageInfo.isXposedModule(): Boolean {
-  val metaData = applicationInfo?.metaData ?: return false
-  return metaData.getBoolean("xposedmodule") || metaData.containsKey("xposedminversion")
+  val metaData = applicationInfo?.metaData
+  if (metaData != null && (metaData.getBoolean("xposedmodule") || metaData.containsKey("xposedminversion"))) {
+    return true
+  }
+  val sourceDir = applicationInfo?.sourceDir ?: return false
+  return runCatching {
+    ZipFileCompat(File(sourceDir)).use {
+      it.getEntry("META-INF/xposed/module.prop") != null
+    }
+  }.getOrDefault(false)
 }
 
 /**

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -172,6 +172,8 @@
   <string name="lib_detail_app_props_title">应用属性</string>
   <string name="lib_detail_app_props_tip">更多资料</string>
   <string name="lib_detail_xposed_min_version">Min 版本</string>
+  <string name="lib_detail_xposed_target_version">Target 版本</string>
+  <string name="lib_detail_xposed_static_scope">静态 Scope</string>
   <string name="lib_detail_xposed_default_scope">默认 Scope</string>
   <string name="lib_detail_xposed_init_class">初始化类</string>
   <string name="lib_detail_app_install_source_title">安装来源</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,8 @@
   <string name="lib_detail_app_props_title">App properties</string>
   <string name="lib_detail_app_props_tip">More details</string>
   <string name="lib_detail_xposed_min_version">Minimum version</string>
+  <string name="lib_detail_xposed_target_version">Target version</string>
+  <string name="lib_detail_xposed_static_scope">Static scope</string>
   <string name="lib_detail_xposed_default_scope">Default scope</string>
   <string name="lib_detail_xposed_init_class">Initialization class</string>
   <string name="lib_detail_app_install_source_title">Installation source</string>


### PR DESCRIPTION
This PR adapts `XposedInfoDialogFragment` and `isXposedModule` to support the Modern Xposed API (API 100) standard.

## Key Changes:

- Module Config: Now parses `META-INF/xposed/module.prop` for `minApiVersion`, `targetApiVersion`, and `staticScope`.
  - The minVersion logic now resolves to the minimum value among `minApiVersion`, `xposedMinVersion`, and legacy metadata.
- Entry Points: Added support for `java_init.list` and `native_init.list` alongside legacy `assets/xposed_init`.
- Scope: Added support for `META-INF/xposed/scope.list`.

## Logic Update:

- `minApiVersion`: Now resolves to the minimum value among `minApiVersion` (new), `xposedMinVersion` (legacy prop), and `xposedminversion` (metadata).
- `isXposedModule`: Added check for `module.prop` existence to detect modern modules without metadata.

## Strings Added:

- `lib_detail_xposed_target_version` ("Target version") 
- `lib_detail_xposed_static_scope` ("Static scope")

## ScreenShots:

| Xposed Info 1 | Xposed Info 2 | Xposed Info 3 |
| :---: | :---: | :---: |
| <img src="https://github.com/user-attachments/assets/3dd5e5e1-c50a-4589-b610-7d70e8e522cd" width="300"/> | <img src="https://github.com/user-attachments/assets/c404f27b-9478-4a39-a39f-29c1ae335aac" width="300"/> | <img src="https://github.com/user-attachments/assets/9bb6b388-f26f-41a8-99b2-5c9722953743" width="300"/> |
