### PR TITLE
fix: Update `LocalAppDataSource` calls to force cache refresh in `HomeViewModel`

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/home/HomeViewModel.kt
@@ -164,7 +164,7 @@ class HomeViewModel : ViewModel() {
       return
     }
     viewModelScope.launch {
-      initJob = initItemsImpl(context, LocalAppDataSource.getApplicationList())
+      initJob = initItemsImpl(context, LocalAppDataSource.getApplicationList(true))
     }
   }
 
@@ -264,8 +264,8 @@ class HomeViewModel : ViewModel() {
       }
     } else {
       val dbApps = dbItems.map { it.packageName }.toSet()
-      var applications = LocalAppDataSource.getApplicationMap()
-      var localApps = applications.map { it -> it.key }.toSet()
+      var applications = LocalAppDataSource.getApplicationMap(true)
+      var localApps = applications.map { it.key }.toSet()
       var newApps = localApps - dbApps
       var removedApps = dbApps - localApps
 
@@ -276,7 +276,7 @@ class HomeViewModel : ViewModel() {
       if (newApps.size > 30 || removedApps.size > 30) {
         Timber.w("Request change canceled because of large diff, re-request appMap")
         applications = LocalAppDataSource.getApplicationMap(true)
-        localApps = applications.map { it -> it.key }.toSet()
+        localApps = applications.map { it.key }.toSet()
         newApps = localApps - dbApps
         removedApps = dbApps - localApps
       }


### PR DESCRIPTION
This PR fixes the issue where the application list fails to load immediately after the "Query All Packages" permission is granted (especially on Chinese oems), which previously required an app restart to take effect.

## Changes:

- `HomeViewModel` Initialization: Updated `initItems` to force a refresh of the local application data source during the initial scan.
- `HomeViewModel` Change Request: Updated `requestChangeImpl` to force a refresh of the application map when a full update (force update) is triggered.
- Removed redundant lambda arrow as Android Studio suggested

## Question:

I’m not sure why `forceUpdate` was previously set to `false` in all cases, but I’ve changed it to `true` to proactively address this issue.

With this change, the problem is resolved, and based on my testing, it does not appear to affect startup performance. I’ve also shared a short screen recording demonstrating this fix in the [Telegram group](https://t.me/libcheckerr/343688) for reference.

That said, this is just my personal observation. While changing this value fixes the issue, any potential performance implications should still be evaluated.