### PR TITLE
Fix bottom navigation covering statistics search results

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/features/statistics/ui/LibReferenceFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/statistics/ui/LibReferenceFragment.kt
@@ -362,6 +362,7 @@ class LibReferenceFragment :
               //noinspection NotifyDataSetChanged
               refAdapter.notifyDataSetChanged()
             }
+            refAdapter.setSpaceFooterView()
           }
           binding.list.post {
             (activity as? INavViewContainer)?.hideProgressBar()


### PR DESCRIPTION
Closes #1958 

`统计`页在搜索结果更新后，没有重新计算列表底部的补白 spacer。此 PR 在统计页搜索结果 `setDiffNewData(...) `完成后，加上一次 `setSpaceFooterView()` 调用，让搜索后的列表正确更新底部补白。

### 修复后的效果
![19442243ACB55450B24C7A403EF9A362](https://github.com/user-attachments/assets/e69469ff-cf88-4c6c-8132-be575519f092)
