### PR TITLE
Separate advanced menu sections: filter, view

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/features/applist/ui/AdvancedMenuBSDFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/applist/ui/AdvancedMenuBSDFragment.kt
@@ -6,6 +6,7 @@ import com.absinthe.libchecker.constant.GlobalValues
 import com.absinthe.libchecker.constant.options.AdvancedOptions
 import com.absinthe.libchecker.features.applist.ui.view.AdvancedMenuBSDView
 import com.absinthe.libchecker.features.applist.ui.view.AdvancedMenuItemView
+import com.absinthe.libchecker.features.applist.ui.view.AdvancedMenuSection
 import com.absinthe.libchecker.ui.base.BaseBottomSheetViewDialogFragment
 import com.absinthe.libraries.utils.view.BottomSheetHeaderView
 
@@ -29,11 +30,11 @@ class AdvancedMenuBSDFragment : BaseBottomSheetViewDialogFragment<AdvancedMenuBS
     optionsViewMap[AdvancedOptions.SHOW_OVERLAYS] = root.addOptionItemView(R.string.adv_show_overlays, AdvancedOptions.SHOW_OVERLAYS)
     optionsViewMap[AdvancedOptions.SHOW_64_BIT_APPS] = root.addOptionItemView(R.string.adv_show_64_bit, AdvancedOptions.SHOW_64_BIT_APPS)
     optionsViewMap[AdvancedOptions.SHOW_32_BIT_APPS] = root.addOptionItemView(R.string.adv_show_32_bit, AdvancedOptions.SHOW_32_BIT_APPS)
-    optionsViewMap[AdvancedOptions.SHOW_ANDROID_VERSION] = root.addOptionItemView(R.string.adv_show_android_version, AdvancedOptions.SHOW_ANDROID_VERSION)
-    optionsViewMap[AdvancedOptions.SHOW_TARGET_API] = root.addOptionItemView(R.string.adv_show_target_version, AdvancedOptions.SHOW_TARGET_API)
-    optionsViewMap[AdvancedOptions.SHOW_MIN_API] = root.addOptionItemView(R.string.adv_show_min_version, AdvancedOptions.SHOW_MIN_API)
-    optionsViewMap[AdvancedOptions.SHOW_COMPILE_API] = root.addOptionItemView(R.string.adv_show_compile_version, AdvancedOptions.SHOW_COMPILE_API)
-    optionsViewMap[AdvancedOptions.TINT_ABI_LABEL] = root.addOptionItemView(R.string.adv_tint_abi_label, AdvancedOptions.TINT_ABI_LABEL)
+    optionsViewMap[AdvancedOptions.SHOW_ANDROID_VERSION] = root.addOptionItemView(R.string.adv_show_android_version, AdvancedOptions.SHOW_ANDROID_VERSION, AdvancedMenuSection.View)
+    optionsViewMap[AdvancedOptions.SHOW_TARGET_API] = root.addOptionItemView(R.string.adv_show_target_version, AdvancedOptions.SHOW_TARGET_API, AdvancedMenuSection.View)
+    optionsViewMap[AdvancedOptions.SHOW_MIN_API] = root.addOptionItemView(R.string.adv_show_min_version, AdvancedOptions.SHOW_MIN_API, AdvancedMenuSection.View)
+    optionsViewMap[AdvancedOptions.SHOW_COMPILE_API] = root.addOptionItemView(R.string.adv_show_compile_version, AdvancedOptions.SHOW_COMPILE_API, AdvancedMenuSection.View)
+    optionsViewMap[AdvancedOptions.TINT_ABI_LABEL] = root.addOptionItemView(R.string.adv_tint_abi_label, AdvancedOptions.TINT_ABI_LABEL, AdvancedMenuSection.View)
 
     optionsViewMap[AdvancedOptions.SHOW_ANDROID_VERSION]?.setOnCheckedChangeCallback {
       root.updateDemoView()

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/applist/ui/view/AdvancedMenuBSDView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/applist/ui/view/AdvancedMenuBSDView.kt
@@ -31,6 +31,13 @@ import com.google.android.flexbox.FlexboxLayout
 import com.google.android.flexbox.JustifyContent
 import com.google.android.material.card.MaterialCardView
 
+enum class AdvancedMenuSection {
+  /** Option section for app list filtering. */
+  Filter,
+  /** Option section for app list view. */
+  View
+}
+
 class AdvancedMenuBSDView(context: Context) :
   LinearLayout(context),
   IHeaderView {
@@ -83,6 +90,18 @@ class AdvancedMenuBSDView(context: Context) :
   }
 
   private val flexLayout = FlexboxLayout(context).apply {
+    layoutParams = LayoutParams(
+      LayoutParams.MATCH_PARENT,
+      LayoutParams.WRAP_CONTENT
+    ).also {
+      it.topMargin = 8.dp
+    }
+    flexWrap = FlexWrap.WRAP
+    justifyContent = JustifyContent.FLEX_START
+    flexDirection = FlexDirection.ROW
+  }
+
+  private val flexLayout2 = FlexboxLayout(context).apply {
     layoutParams = LayoutParams(
       LayoutParams.MATCH_PARENT,
       LayoutParams.WRAP_CONTENT
@@ -199,12 +218,22 @@ class AdvancedMenuBSDView(context: Context) :
       addData(demoView)
       addData(sortView)
       addData(flexLayout)
+      addData(flexLayout2)
       addData(itemView)
       addData(itemFlexLayout)
     }
   }
 
+  /** Add an option item to the [Filter][AdvancedMenuSection.Filter] section. */
   fun addOptionItemView(labelRes: Int, option: Int): AdvancedMenuItemView {
+    return addOptionItemView(labelRes, option, AdvancedMenuSection.Filter)
+  }
+
+  fun addOptionItemView(labelRes: Int, option: Int, section: AdvancedMenuSection): AdvancedMenuItemView {
+    val flexLayout = when (section) {
+      AdvancedMenuSection.Filter -> flexLayout
+      AdvancedMenuSection.View -> flexLayout2
+    }
     val view = AdvancedMenuItemView(context).apply {
       setOption(labelRes, option)
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/features/applist/ui/view/AdvancedMenuBSDView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/features/applist/ui/view/AdvancedMenuBSDView.kt
@@ -34,6 +34,7 @@ import com.google.android.material.card.MaterialCardView
 enum class AdvancedMenuSection {
   /** Option section for app list filtering. */
   Filter,
+
   /** Option section for app list view. */
   View
 }


### PR DESCRIPTION
### Intention
Separate options in advance menu into two sections: `Filter` (app list filtering), and `View` (app list view).
This delivers more function clarity to the end users, making the UI easier to understand and use.
### Before vs. After Change
<img width="270" alt="Screenshot_20260517-193438" src="https://github.com/user-attachments/assets/6d60153e-2a67-4d92-9703-22ab1395e1ba" />  <img width="270" alt="Screenshot_20260517-193344" src="https://github.com/user-attachments/assets/eda4b418-ae8c-4d39-bcc0-b6d8896527d9" />
