### PR TITLE
feat: add provider permission reference for permission long-press menu

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/di/AppDetailModule.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/di/AppDetailModule.kt
@@ -35,10 +35,10 @@ import com.absinthe.libchecker.domain.app.detail.action.GetAppInstallSourceDetai
 import com.absinthe.libchecker.domain.app.detail.action.GetAppLaunchActionUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetAppManifestPropertiesUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetElfDetailUseCase
-import com.absinthe.libchecker.domain.app.detail.action.GetPermissionProvidersUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetLibraryDetailDialogDataUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetOverlayDetailUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetPermissionDetailUseCase
+import com.absinthe.libchecker.domain.app.detail.action.GetPermissionProvidersUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetXposedModuleInfoUseCase
 import com.absinthe.libchecker.domain.app.detail.action.PrepareAppPackageShareActionUseCase
 import com.absinthe.libchecker.domain.app.detail.action.PrepareAppPackageShareFileUseCase

--- a/app/src/main/kotlin/com/absinthe/libchecker/di/AppDetailModule.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/di/AppDetailModule.kt
@@ -35,6 +35,7 @@ import com.absinthe.libchecker.domain.app.detail.action.GetAppInstallSourceDetai
 import com.absinthe.libchecker.domain.app.detail.action.GetAppLaunchActionUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetAppManifestPropertiesUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetElfDetailUseCase
+import com.absinthe.libchecker.domain.app.detail.action.GetPermissionProvidersUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetLibraryDetailDialogDataUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetOverlayDetailUseCase
 import com.absinthe.libchecker.domain.app.detail.action.GetPermissionDetailUseCase
@@ -115,6 +116,7 @@ val appDetailModule = module {
   factory { BuildRelatedAppDisplayDataUseCase(androidContext()) }
   factory { BuildDetailItemDialogRequestUseCase() }
   factory { BuildDetailItemLongClickActionsUseCase() }
+  factory { GetPermissionProvidersUseCase(get()) }
   factory { BuildDetailReferenceNavigationUseCase() }
   factory { BuildSignatureDetailItemsUseCase() }
   factory { GetAppManifestPropertiesUseCase(androidContext().packageManager) }

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/action/BuildDetailItemLongClickActionsUseCase.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/action/BuildDetailItemLongClickActionsUseCase.kt
@@ -33,7 +33,8 @@ class BuildDetailItemLongClickActionsUseCase {
       elfExtractAvailable = request.detailType == NATIVE && !request.isApkPreview,
       elfInfo = buildElfInfo(request, item),
       reference = buildReference(request, componentName, item),
-      integrationsAvailable = !request.isApk && !request.isApkPreview
+      integrationsAvailable = !request.isApk && !request.isApkPreview,
+      providerPermissionAvailable = request.detailType == PERMISSION && !request.isApkPreview
     )
   }
 
@@ -98,7 +99,8 @@ data class DetailItemLongClickActions(
   val elfExtractAvailable: Boolean,
   val elfInfo: DetailItemElfInfoAction?,
   val reference: DetailItemReferenceAction?,
-  val integrationsAvailable: Boolean
+  val integrationsAvailable: Boolean,
+  val providerPermissionAvailable: Boolean = false
 )
 
 data class DetailItemElfInfoAction(

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/action/GetPermissionProvidersUseCase.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/action/GetPermissionProvidersUseCase.kt
@@ -1,0 +1,59 @@
+package com.absinthe.libchecker.domain.app.detail.action
+
+import android.content.pm.PackageManager
+import com.absinthe.libchecker.domain.app.InstalledAppRepository
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import timber.log.Timber
+
+data class ProviderPermissionItem(
+  val packageName: String,
+  val providerName: String
+)
+
+class GetPermissionProvidersUseCase(
+  private val installedAppRepository: InstalledAppRepository
+) {
+
+  suspend operator fun invoke(permissionName: String): List<ProviderPermissionItem> {
+    val apps = installedAppRepository.getApplicationList()
+    val result = mutableListOf<ProviderPermissionItem>()
+    val seenPackages = mutableSetOf<String>()
+    val coroutineContext = currentCoroutineContext()
+
+    for (app in apps) {
+      if (!coroutineContext.isActive) {
+        return result
+      }
+
+      val packageInfo = runCatching {
+        installedAppRepository.getPackageInfo(
+          app.packageName,
+          PackageManager.GET_PROVIDERS
+        )
+      }.onFailure {
+        Timber.w(it, "Failed to get package info for ${app.packageName}")
+      }.getOrNull() ?: continue
+
+      val providers = packageInfo.providers ?: continue
+
+      for (provider in providers) {
+        if (provider.readPermission == permissionName ||
+          provider.writePermission == permissionName
+        ) {
+          if (seenPackages.add(app.packageName)) {
+            result.add(
+              ProviderPermissionItem(
+                packageName = app.packageName,
+                providerName = provider.name
+              )
+            )
+          }
+          break
+        }
+      }
+    }
+
+    return result
+  }
+}

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/base/BaseDetailFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/base/BaseDetailFragment.kt
@@ -18,6 +18,7 @@ import com.absinthe.libchecker.domain.app.AppListSettingsRepository
 import com.absinthe.libchecker.domain.app.BuildNativeLibraryItemDisplayDataUseCase
 import com.absinthe.libchecker.domain.app.ResolveAppResourceValueUseCase
 import com.absinthe.libchecker.domain.app.detail.action.DetailItemDialogRequest
+import com.absinthe.libchecker.domain.app.detail.action.GetPermissionProvidersUseCase
 import com.absinthe.libchecker.domain.app.detail.model.LibStringItemChip
 import com.absinthe.libchecker.domain.app.detail.navigation.EXTRA_PACKAGE_NAME
 import com.absinthe.libchecker.domain.app.detail.presentation.DetailViewModel
@@ -60,6 +61,7 @@ abstract class BaseDetailFragment<T : ViewBinding> :
   private val appListSettingsRepository: AppListSettingsRepository by inject()
   private val buildNativeLibraryItemDisplayData: BuildNativeLibraryItemDisplayDataUseCase by inject()
   private val resolveAppResourceValue: ResolveAppResourceValueUseCase by inject()
+  private val getPermissionProvidersUseCase: GetPermissionProvidersUseCase by inject()
   protected val packageName by lazy { arguments?.getString(EXTRA_PACKAGE_NAME).orEmpty() }
   protected val type by lazy { arguments?.getInt(EXTRA_TYPE) ?: NATIVE }
   protected val adapter by lazy {
@@ -100,7 +102,8 @@ abstract class BaseDetailFragment<T : ViewBinding> :
       adapter = adapter,
       coroutineScope = lifecycleScope,
       packageName = { packageName },
-      type = { type }
+      type = { type },
+      getPermissionProvidersUseCase = getPermissionProvidersUseCase
     )
   }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/base/DetailItemLongClickController.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/base/DetailItemLongClickController.kt
@@ -5,6 +5,7 @@ import android.widget.TextView
 import com.absinthe.libchecker.annotation.ACTIVITY
 import com.absinthe.libchecker.compat.VersionCompat
 import com.absinthe.libchecker.domain.app.detail.action.DetailItemLongClickActions
+import com.absinthe.libchecker.domain.app.detail.action.GetPermissionProvidersUseCase
 import com.absinthe.libchecker.domain.app.detail.model.LibStringItemChip
 import com.absinthe.libchecker.domain.app.detail.presentation.DetailViewModel
 import com.absinthe.libchecker.domain.app.detail.ui.Referable
@@ -34,7 +35,8 @@ class DetailItemLongClickController(
   private val adapter: LibStringAdapter,
   private val coroutineScope: CoroutineScope,
   private val packageName: () -> String,
-  private val type: () -> Int
+  private val type: () -> Int,
+  private val getPermissionProvidersUseCase: GetPermissionProvidersUseCase
 ) {
   private var integrationMonkeyKingBlockList: List<ShareCmpInfo.Component>? = null
   private var integrationBlockerList: List<ShareCmpInfo.Component>? = null
@@ -54,6 +56,7 @@ class DetailItemLongClickController(
     addCopyAction(arrayAdapter, actionMap, actions)
     addElfActions(arrayAdapter, actionMap, item, actions)
     addReferenceAction(arrayAdapter, actionMap, actions)
+    addProviderPermissionAction(arrayAdapter, actionMap, actions)
     addIntegrationActions(arrayAdapter, actionMap, actions, position)
 
     BaseAlertDialogBuilder(context)
@@ -131,6 +134,38 @@ class DetailItemLongClickController(
     arrayAdapter.add(fragment.getString(com.absinthe.libchecker.R.string.tab_lib_reference_statistics))
     actionMap[arrayAdapter.count - 1] = {
       fragment.activity?.launchLibReferencePage(reference.refName, reference.label, reference.type, null)
+    }
+  }
+
+  private fun addProviderPermissionAction(
+    arrayAdapter: ArrayAdapter<String>,
+    actionMap: MutableMap<Int, () -> Unit>,
+    actions: DetailItemLongClickActions
+  ) {
+    if (!actions.providerPermissionAvailable) {
+      return
+    }
+
+    val context = fragment.requireContext()
+    arrayAdapter.add(fragment.getString(com.absinthe.libchecker.R.string.lib_detail_permission_providers))
+    actionMap[arrayAdapter.count - 1] = {
+      val loading = UiUtils.createLoadingDialog(fragment.requireActivity())
+      loading.show()
+      coroutineScope.launch {
+        val items = getPermissionProvidersUseCase(actions.componentName)
+        loading.dismiss()
+        if (items.isNotEmpty()) {
+          val encodedList = items.map { "${it.packageName}|${it.providerName}" }.toTypedArray()
+          fragment.activity?.launchLibReferencePage(
+            refName = actions.componentName,
+            refLabel = fragment.getString(com.absinthe.libchecker.R.string.lib_detail_permission_providers),
+            refType = com.absinthe.libchecker.annotation.PROVIDER,
+            refList = encodedList
+          )
+        } else {
+          context.showToast(com.absinthe.libchecker.R.string.lib_detail_permission_providers_empty)
+        }
+      }
     }
   }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/reference/ui/LibReferenceActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/reference/ui/LibReferenceActivity.kt
@@ -1,5 +1,6 @@
 package com.absinthe.libchecker.domain.statistics.reference.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.ViewGroup
@@ -7,6 +8,7 @@ import androidx.lifecycle.lifecycleScope
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.annotation.ACTION
 import com.absinthe.libchecker.annotation.NATIVE
+import com.absinthe.libchecker.annotation.PROVIDER
 import com.absinthe.libchecker.databinding.ActivityLibReferenceBinding
 import com.absinthe.libchecker.domain.app.list.ui.adapter.AppAdapter
 import com.absinthe.libchecker.domain.statistics.reference.presentation.LibReferenceViewModel
@@ -29,14 +31,23 @@ class LibReferenceActivity : BaseActivity<ActivityLibReferenceBinding>() {
 
   private val adapter = AppAdapter()
   private val viewModel: LibReferenceViewModel by viewModel()
-  private val refName by lazy { intent.extras?.getString(EXTRA_REF_NAME) }
-  private val refLabel by lazy { intent.extras?.getString(EXTRA_REF_LABEL) }
-  private val refType by lazy { intent.extras?.getInt(EXTRA_REF_TYPE) ?: NATIVE }
-  private val refList by lazy { intent.extras?.getStringArray(EXTRA_REF_LIST) }
+  private var refName: String? = null
+  private var refLabel: String? = null
+  private var refType: Int = NATIVE
+  private var refList: Array<String>? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    readIntentExtras()
     initView()
+    initData()
+  }
+
+  override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    readIntentExtras()
+    updateActionBar()
     initData()
   }
 
@@ -47,14 +58,23 @@ class LibReferenceActivity : BaseActivity<ActivityLibReferenceBinding>() {
     return super.onOptionsItemSelected(item)
   }
 
-  private fun initView() {
-    setSupportActionBar(binding.toolbar)
+  private fun readIntentExtras() {
+    refName = intent.extras?.getString(EXTRA_REF_NAME)
+    refLabel = intent.extras?.getString(EXTRA_REF_LABEL)
+    refType = intent.extras?.getInt(EXTRA_REF_TYPE) ?: NATIVE
+    refList = intent.extras?.getStringArray(EXTRA_REF_LIST)
+  }
+
+  private fun updateActionBar() {
     supportActionBar?.apply {
-      refLabel?.let {
-        title = it
-      }
+      refLabel?.let { title = it }
       subtitle = refName
     }
+  }
+
+  private fun initView() {
+    setSupportActionBar(binding.toolbar)
+    updateActionBar()
     binding.apply {
       supportActionBar?.setDisplayHomeAsUpEnabled(true)
       (root as ViewGroup).bringChildToFront(appbar)
@@ -102,6 +122,11 @@ class LibReferenceActivity : BaseActivity<ActivityLibReferenceBinding>() {
       val (name, type) = if (refType == ACTION) {
         val pair = viewModel.getActionTarget(item.packageName)
         (pair?.first ?: item.packageName) to (pair?.second ?: ACTION)
+      } else if (refList != null && refType == PROVIDER) {
+        val providerName = refList
+          ?.find { it.startsWith(item.packageName + "|") }
+          ?.substringAfter("|")
+        (providerName ?: refName) to refType
       } else {
         refName to refType
       }
@@ -112,7 +137,10 @@ class LibReferenceActivity : BaseActivity<ActivityLibReferenceBinding>() {
 
   private fun initData() {
     this.refName?.let { name ->
-      refList?.toList()?.let { viewModel.setData(name, refType, it) } ?: viewModel.setData(name, refType)
+      refList?.toList()?.let { encodedList ->
+        val pkgNames = encodedList.map { it.substringBefore("|") }
+        viewModel.setData(name, refType, pkgNames)
+      } ?: viewModel.setData(name, refType)
     } ?: finish()
   }
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -205,6 +205,8 @@
   <string name="lib_detail_elf_extract">提取</string>
   <string name="lib_detail_elf_extract_success">ELF 文件已保存到下载目录</string>
   <string name="lib_detail_elf_extract_failed">提取 ELF 文件失败</string>
+  <string name="lib_detail_permission_providers">提供者引用统计</string>
+  <string name="lib_detail_permission_providers_empty">没有内容提供者使用此权限</string>
   <string name="lib_detail_dependency_tip">依赖</string>
   <string name="lib_detail_entry_points_tip">入口点</string>
   <string name="lib_detail_optimization_tip">优化</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,6 +217,8 @@
   <string name="lib_detail_elf_extract">Extract</string>
   <string name="lib_detail_elf_extract_success">ELF file saved to Downloads</string>
   <string name="lib_detail_elf_extract_failed">Failed to extract ELF file</string>
+  <string name="lib_detail_permission_providers">Provider reference</string>
+  <string name="lib_detail_permission_providers_empty">No content provider uses this permission</string>
   <string name="lib_detail_dependency_tip">Dependencies</string>
   <string name="lib_detail_entry_points_tip">Entry points</string>
   <string name="lib_detail_optimization_tip">Optimization</string>


### PR DESCRIPTION
Add a new menu item 'Provider reference' (提供者引用统计) when long-pressing a permission item in the app detail page. The feature queries all installed apps to find which ContentProviders declare a readPermission or writePermission matching the selected permission, then shows the results in LibReferenceActivity.

Changes by file:

- GetPermissionProvidersUseCase.kt (new): Iterates all installed apps via InstalledAppRepository, fetches ProviderInfo for each via PackageManager.GET_PROVIDERS, and collects providers whose readPermission or writePermission matches the target permission name.

- AppDetailModule.kt: Register GetPermissionProvidersUseCase in Koin DI module.

- DetailItemLongClickActions / BuildDetailItemLongClickActionsUseCase.kt: Add providerPermissionAvailable flag, enabled for PERMISSION type when not in APK preview mode.

- DetailItemLongClickController.kt: Accept GetPermissionProvidersUseCase via constructor. Add new addProviderPermissionAction() method that shows loading dialog, queries matching providers, encodes results as 'packageName|providerName' in refList, and launches LibReferenceActivity with refType=PROVIDER.

- LibReferenceActivity.kt: Fix singleTask launchMode issue: convert lazy intent-extras to mutable fields with readIntentExtras(); add onNewIntent() override to re-read extras on subsequent launches. Decode encoded refList in initData() for the PROVIDER case. Resolve per-item provider name from refList in click handler so navigation targets the correct provider tab item.

- BaseDetailFragment.kt: Inject GetPermissionProvidersUseCase and pass to controller.

- strings.xml (values + values-zh-rCN): Add lib_detail_permission_providers and lib_detail_permission_providers_empty string resources.