### PR TITLE
Keep snapshot detail rows full width

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,9 @@ Important `:app` boundaries:
 
 ## Data, UI, and release constraints
 
+- Keep full-width selectable or hoverable list rows edge-to-edge. Put horizontal
+  page spacing in each row's content padding, not item margins or parent-list
+  horizontal padding, so selector and hover feedback have no side gaps.
 - Room schema changes require a database version bump, migration or
   auto-migration, and updated `app/schemas/`.
 - UI controllers should not call `Repositories.lcRepository` directly for new

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/detail/ui/view/SnapshotDetailItemView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/detail/ui/view/SnapshotDetailItemView.kt
@@ -26,12 +26,15 @@ import com.absinthe.libchecker.domain.snapshot.detail.ui.model.resolveSnapshotDe
 import com.absinthe.libchecker.utils.extensions.dp
 import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getColorByAttr
+import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
 import com.absinthe.libchecker.utils.extensions.getResourceIdByAttr
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.R as MaterialR
 import com.google.android.material.chip.Chip
 
 class SnapshotDetailItemView(context: Context) : AViewGroup(context) {
+
+  private val horizontalContentPadding = context.getDimensionPixelSize(R.dimen.normal_padding)
 
   private val statusRail = View(context).apply {
     layoutParams = ViewGroup.LayoutParams(STATUS_RAIL_WIDTH, ViewGroup.LayoutParams.MATCH_PARENT)
@@ -206,9 +209,12 @@ class SnapshotDetailItemView(context: Context) : AViewGroup(context) {
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     super.onMeasure(widthMeasureSpec, heightMeasureSpec)
     children.filter { it !== divider }.forEach { it.autoMeasure() }
-    divider.measure(measuredWidth.toExactlyMeasureSpec(), DIVIDER_HEIGHT.toExactlyMeasureSpec())
+    val dividerWidth = (measuredWidth - horizontalContentPadding * 2).coerceAtLeast(0)
+    divider.measure(dividerWidth.toExactlyMeasureSpec(), DIVIDER_HEIGHT.toExactlyMeasureSpec())
 
-    val contentWidth = measuredWidth - STATUS_RAIL_WIDTH - CONTENT_START_GAP - CONTENT_END_PADDING
+    val contentWidth = (
+      measuredWidth - horizontalContentPadding * 2 - STATUS_RAIL_WIDTH - CONTENT_START_GAP
+      ).coerceAtLeast(0)
     val statusClusterWidth = statusIcon.measuredWidth + STATUS_LABEL_GAP + statusLabel.measuredWidth
     layoutPlan = planSnapshotDetailItemLayout(
       contentWidth = contentWidth,
@@ -255,8 +261,13 @@ class SnapshotDetailItemView(context: Context) : AViewGroup(context) {
   }
 
   override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-    statusRail.layout(0, 0, STATUS_RAIL_WIDTH, measuredHeight)
-    val contentStart = STATUS_RAIL_WIDTH + CONTENT_START_GAP
+    statusRail.layout(
+      horizontalContentPadding,
+      0,
+      horizontalContentPadding + STATUS_RAIL_WIDTH,
+      measuredHeight
+    )
+    val contentStart = horizontalContentPadding + STATUS_RAIL_WIDTH + CONTENT_START_GAP
     val statusClusterWidth = statusIcon.measuredWidth + STATUS_LABEL_GAP + statusLabel.measuredWidth
     val statusRowHeight = maxOf(
       statusIcon.measuredHeight,
@@ -298,7 +309,12 @@ class SnapshotDetailItemView(context: Context) : AViewGroup(context) {
       nextY + RULE_CHIP_VERTICAL_GAP
     )
     updateChipTouchDelegate()
-    divider.layout(0, measuredHeight - DIVIDER_HEIGHT)
+    divider.layout(
+      horizontalContentPadding,
+      measuredHeight - DIVIDER_HEIGHT,
+      horizontalContentPadding + divider.measuredWidth,
+      measuredHeight
+    )
   }
 
   private fun updateChipTouchDelegate() {
@@ -319,7 +335,6 @@ class SnapshotDetailItemView(context: Context) : AViewGroup(context) {
     val STATUS_TITLE_GAP = 12.dp
     val TITLE_CHIP_GAP = 6.dp
     val CONTENT_START_GAP = 12.dp
-    val CONTENT_END_PADDING = 12.dp
     val CONTENT_TOP_PADDING = 8.dp
     val CONTENT_BOTTOM_PADDING = 8.dp
     val STACKED_TITLE_GAP = 4.dp

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/detail/ui/view/SnapshotDetailTitleView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/detail/ui/view/SnapshotDetailTitleView.kt
@@ -19,6 +19,7 @@ import com.absinthe.libchecker.domain.snapshot.detail.ui.model.SnapshotDetailTit
 import com.absinthe.libchecker.utils.extensions.dp
 import com.absinthe.libchecker.utils.extensions.getColor
 import com.absinthe.libchecker.utils.extensions.getColorByAttr
+import com.absinthe.libchecker.utils.extensions.getDimensionPixelSize
 import com.absinthe.libchecker.utils.extensions.getResourceIdByAttr
 import com.absinthe.libchecker.view.AViewGroup
 import com.google.android.material.R as MaterialR
@@ -69,7 +70,8 @@ class SnapshotDetailTitleView(context: Context) : AViewGroup(context) {
 
   init {
     minimumHeight = 52.dp
-    setPadding(12.dp, 10.dp, 12.dp, 10.dp)
+    val horizontalPadding = context.getDimensionPixelSize(R.dimen.normal_padding)
+    setPadding(horizontalPadding, 10.dp, horizontalPadding, 10.dp)
     setBackgroundColor(context.getColorByAttr(MaterialR.attr.colorSurface))
     importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
     isFocusable = true

--- a/app/src/main/res/layout/activity_snapshot_detail.xml
+++ b/app/src/main/res/layout/activity_snapshot_detail.xml
@@ -56,7 +56,8 @@
       android:background="?attr/colorSurface"
       android:clipToPadding="false"
       android:overScrollMode="never"
-      android:padding="@dimen/normal_padding"
+      android:paddingTop="@dimen/normal_padding"
+      android:paddingBottom="@dimen/normal_padding"
       app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
   </LinearLayout>


### PR DESCRIPTION
Keep selectable Snapshot Detail rows edge-to-edge by moving horizontal spacing into row content padding.

Depends on #2100. Stack: #2100 → #2101 → #2102

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>