### PR TITLE
Align snapshot header metric baselines

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/detail/ui/view/SnapshotTitleView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/detail/ui/view/SnapshotTitleView.kt
@@ -259,14 +259,24 @@ class SnapshotTitleView(
         valueWidth.toExactlyMeasureSpec(),
         packageSizeView.defaultHeightMeasureSpec(this)
       )
-      contentBottom += maxOf(packageSizeLabelView.measuredHeight, packageSizeView.measuredHeight)
+      contentBottom += planSnapshotMetricRowLayout(
+        labelHeight = packageSizeLabelView.measuredHeight,
+        labelBaseline = packageSizeLabelView.baseline,
+        valueHeight = packageSizeView.measuredHeight,
+        valueBaseline = packageSizeView.baseline
+      ).height
     }
     if (apisView.isVisible) {
       if (packageSizeView.isVisible) {
         contentBottom += METRIC_ROW_GAP
       }
       apisView.measure(valueWidth.toExactlyMeasureSpec(), apisView.defaultHeightMeasureSpec(this))
-      contentBottom += maxOf(apisLabelView.measuredHeight, apisView.measuredHeight)
+      contentBottom += planSnapshotMetricRowLayout(
+        labelHeight = apisLabelView.measuredHeight,
+        labelBaseline = apisLabelView.baseline,
+        valueHeight = apisView.measuredHeight,
+        valueBaseline = apisView.baseline
+      ).height
     }
 
     if (summaryDivider.isVisible) {
@@ -313,17 +323,29 @@ class SnapshotTitleView(
     )
     val valueX = paddingStart + labelWidth + METRIC_GAP
     if (packageSizeView.isVisible) {
-      packageSizeLabelView.layout(paddingStart, nextY)
-      packageSizeView.layout(valueX, nextY)
-      nextY += maxOf(packageSizeLabelView.measuredHeight, packageSizeView.measuredHeight)
+      val row = planSnapshotMetricRowLayout(
+        labelHeight = packageSizeLabelView.measuredHeight,
+        labelBaseline = packageSizeLabelView.baseline,
+        valueHeight = packageSizeView.measuredHeight,
+        valueBaseline = packageSizeView.baseline
+      )
+      packageSizeLabelView.layout(paddingStart, nextY + row.labelTopOffset)
+      packageSizeView.layout(valueX, nextY + row.valueTopOffset)
+      nextY += row.height
     }
     if (apisView.isVisible) {
       if (packageSizeView.isVisible) {
         nextY += METRIC_ROW_GAP
       }
-      apisLabelView.layout(paddingStart, nextY)
-      apisView.layout(valueX, nextY)
-      nextY += maxOf(apisLabelView.measuredHeight, apisView.measuredHeight)
+      val row = planSnapshotMetricRowLayout(
+        labelHeight = apisLabelView.measuredHeight,
+        labelBaseline = apisLabelView.baseline,
+        valueHeight = apisView.measuredHeight,
+        valueBaseline = apisView.baseline
+      )
+      apisLabelView.layout(paddingStart, nextY + row.labelTopOffset)
+      apisView.layout(valueX, nextY + row.valueTopOffset)
+      nextY += row.height
     }
 
     if (summaryDivider.isVisible) {
@@ -382,4 +404,29 @@ class SnapshotTitleView(
     val SUMMARY_GAP = 16.dp
     val SUMMARY_SECOND_LINE_GAP = 4.dp
   }
+}
+
+internal data class SnapshotMetricRowLayout(
+  val labelTopOffset: Int,
+  val valueTopOffset: Int,
+  val height: Int
+)
+
+internal fun planSnapshotMetricRowLayout(
+  labelHeight: Int,
+  labelBaseline: Int,
+  valueHeight: Int,
+  valueBaseline: Int
+): SnapshotMetricRowLayout {
+  val sharedBaseline = maxOf(labelBaseline, valueBaseline)
+  val labelTopOffset = sharedBaseline - labelBaseline
+  val valueTopOffset = sharedBaseline - valueBaseline
+  return SnapshotMetricRowLayout(
+    labelTopOffset = labelTopOffset,
+    valueTopOffset = valueTopOffset,
+    height = maxOf(
+      labelTopOffset + labelHeight,
+      valueTopOffset + valueHeight
+    )
+  )
 }

--- a/app/src/test/kotlin/com/absinthe/libchecker/domain/snapshot/detail/ui/view/SnapshotMetricRowLayoutTest.kt
+++ b/app/src/test/kotlin/com/absinthe/libchecker/domain/snapshot/detail/ui/view/SnapshotMetricRowLayoutTest.kt
@@ -1,0 +1,37 @@
+package com.absinthe.libchecker.domain.snapshot.detail.ui.view
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SnapshotMetricRowLayoutTest {
+
+  @Test
+  fun alignsLabelAndMultilineValueToTheSameFirstBaseline() {
+    val row = planSnapshotMetricRowLayout(
+      labelHeight = 18,
+      labelBaseline = 12,
+      valueHeight = 40,
+      valueBaseline = 16
+    )
+
+    assertEquals(4, row.labelTopOffset)
+    assertEquals(0, row.valueTopOffset)
+    assertEquals(40, row.height)
+    assertEquals(16, row.labelTopOffset + 12)
+    assertEquals(16, row.valueTopOffset + 16)
+  }
+
+  @Test
+  fun includesTheShiftedValueBottomInTheMeasuredHeight() {
+    val row = planSnapshotMetricRowLayout(
+      labelHeight = 24,
+      labelBaseline = 18,
+      valueHeight = 20,
+      valueBaseline = 14
+    )
+
+    assertEquals(0, row.labelTopOffset)
+    assertEquals(4, row.valueTopOffset)
+    assertEquals(24, row.height)
+  }
+}


### PR DESCRIPTION
Align Snapshot Detail header metrics on a shared baseline and add regression coverage for the metric-row layout.

Depends on #2101. Stack: #2100 → #2101 → #2102

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>