### PR TITLE
图表模块短标题支持

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/dialog/AppStatisticAnalysisBottomSheetDialogFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/dialog/AppStatisticAnalysisBottomSheetDialogFragment.kt
@@ -25,7 +25,11 @@ class AppStatisticAnalysisBottomSheetDialogFragment : BaseBottomSheetViewDialogF
     return AppStatisticAnalysisBottomSheetView(
       context = requireContext(),
       onAnalysisClick = { analysis ->
-        AppStatisticRuleDetailsDialog.show(requireContext(), analysis)
+        AppStatisticRuleDetailsDialog.show(
+          requireContext(),
+          analysis,
+          viewLifecycleOwner.lifecycleScope
+        )
       }
     )
   }

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/dialog/AppStatisticRuleDetailsDialog.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/dialog/AppStatisticRuleDetailsDialog.kt
@@ -7,37 +7,46 @@ import androidx.core.net.toUri
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.domain.app.detail.statistics.AppStatisticRuleAnalysis
 import com.absinthe.libchecker.domain.statistics.chart.ui.resolve
+import com.absinthe.libchecker.domain.statistics.chart.ui.resolveDrawable
 import com.absinthe.libchecker.ui.base.BaseAlertDialogBuilder
 import com.absinthe.libchecker.utils.Toasty
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 object AppStatisticRuleDetailsDialog {
 
-  fun show(context: Context, analysis: AppStatisticRuleAnalysis) {
-    val details = analysis.definition.details ?: return
-    val message = buildList {
-      add(details.description.resolve(context))
-      analysis.resolveMatchedFacetTitles(context).takeIf(List<String>::isNotEmpty)?.let { titles ->
-        add(
-          buildString {
-            append(context.getString(R.string.app_detail_online_rules_detected_features))
-            titles.forEach { title ->
-              append("\n • ")
-              append(title)
+  fun show(context: Context, analysis: AppStatisticRuleAnalysis, scope: CoroutineScope) {
+    scope.launch {
+      val details = analysis.definition.details ?: return@launch
+      val message = buildList {
+        add(details.description.resolve(context))
+        analysis.resolveMatchedFacetTitles(context).takeIf(List<String>::isNotEmpty)?.let { titles ->
+          add(
+            buildString {
+              append(context.getString(R.string.app_detail_online_rules_detected_features))
+              append("\n")
+              titles.forEach { title ->
+                append("\n • ")
+                append(title)
+              }
             }
-          }
-        )
-      }
-    }.joinToString("\n\n")
+          )
+        }
+      }.joinToString("\n\n")
 
-    BaseAlertDialogBuilder(context)
-      .setTitle(analysis.definition.title.resolve(context))
-      .setMessage(message)
-      .setPositiveButton(android.R.string.ok, null)
-      .setNeutralButton(R.string.lib_detail_app_props_tip) { _, _ ->
-        openReference(context, details.referenceUrl)
-      }
-      .show()
+      val iconRes = analysis.definition.icon.resolveDrawable(context)
+
+      BaseAlertDialogBuilder(context)
+        .setIcon(iconRes)
+        .setTitle(analysis.definition.title.resolve(context))
+        .setMessage(message)
+        .setPositiveButton(android.R.string.ok, null)
+        .setNeutralButton(R.string.lib_detail_app_props_tip) { _, _ ->
+          openReference(context, details.referenceUrl)
+        }
+        .show()
+    }
   }
 
   private fun AppStatisticRuleAnalysis.resolveMatchedFacetTitles(context: Context): List<String> {

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/view/AppStatisticAnalysisBottomSheetView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/view/AppStatisticAnalysisBottomSheetView.kt
@@ -18,6 +18,7 @@ import com.absinthe.libchecker.domain.app.detail.statistics.AppStatisticRuleAnal
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticCalculationKind
 import com.absinthe.libchecker.domain.statistics.chart.ui.loadStatisticIcon
 import com.absinthe.libchecker.domain.statistics.chart.ui.resolve
+import com.absinthe.libchecker.domain.statistics.chart.ui.summaryTitle
 import com.absinthe.libchecker.ui.app.BottomSheetRecyclerView
 import com.absinthe.libchecker.utils.extensions.addPaddingTop
 import com.absinthe.libchecker.utils.extensions.dp
@@ -303,7 +304,7 @@ private class AppStatisticAnalysisItemView(context: Context) : LinearLayout(cont
           val matchedIds = matchedFacetIds.toSet()
           facets.items
             .filter { facet -> facet.id in matchedIds }
-            .joinToString(" · ") { facet -> facet.shortTitle?.resolve(context) ?: facet.title.resolve(context) }
+            .joinToString(" · ") { facet -> facet.summaryTitle.resolve(context) }
         }
       }.orEmpty()
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/view/AppStatisticAnalysisBottomSheetView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/detail/ui/view/AppStatisticAnalysisBottomSheetView.kt
@@ -303,7 +303,7 @@ private class AppStatisticAnalysisItemView(context: Context) : LinearLayout(cont
           val matchedIds = matchedFacetIds.toSet()
           facets.items
             .filter { facet -> facet.id in matchedIds }
-            .joinToString(" · ") { facet -> facet.title.resolve(context) }
+            .joinToString(" · ") { facet -> facet.shortTitle?.resolve(context) ?: facet.title.resolve(context) }
         }
       }.orEmpty()
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/model/StatisticDefinition.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/model/StatisticDefinition.kt
@@ -79,6 +79,7 @@ data class StatisticFacetsSpec(
 data class StatisticFacetSpec(
   val id: String,
   val title: StatisticTitleSpec,
+  val shortTitle: StatisticTitleSpec? = null,
   val condition: StatisticConditionSpec
 )
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/source/impl/FacetStatisticChartDataSource.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/source/impl/FacetStatisticChartDataSource.kt
@@ -10,6 +10,7 @@ import com.absinthe.libchecker.domain.statistics.chart.model.StatisticIconSpec
 import com.absinthe.libchecker.domain.statistics.chart.source.BaseChartDataSource
 import com.absinthe.libchecker.domain.statistics.chart.source.IHeavyWork
 import com.absinthe.libchecker.domain.statistics.chart.ui.resolve
+import com.absinthe.libchecker.domain.statistics.chart.ui.summaryTitle
 import com.absinthe.libchecker.domain.statistics.chart.usecase.FacetStatisticData
 import com.absinthe.libchecker.utils.extensions.getColorByAttr
 import info.appdev.charting.charts.PieChart
@@ -47,7 +48,7 @@ class FacetStatisticChartDataSource(
         facets.unmatchedTitle.resolve(context)
       )
       val facetTitles = facets.items.associate { facet ->
-        facet.id to (facet.shortTitle?.resolve(context) ?: facet.title.resolve(context))
+        facet.id to facet.summaryTitle.resolve(context)
       }
       val itemChips = data.matchedFacetIds.mapValues { (_, facetIds) ->
         facetIds.mapNotNull(facetTitles::get)

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/source/impl/FacetStatisticChartDataSource.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/source/impl/FacetStatisticChartDataSource.kt
@@ -47,7 +47,7 @@ class FacetStatisticChartDataSource(
         facets.unmatchedTitle.resolve(context)
       )
       val facetTitles = facets.items.associate { facet ->
-        facet.id to facet.title.resolve(context)
+        facet.id to (facet.shortTitle?.resolve(context) ?: facet.title.resolve(context))
       }
       val itemChips = data.matchedFacetIds.mapValues { (_, facetIds) ->
         facetIds.mapNotNull(facetTitles::get)

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentation.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentation.kt
@@ -14,6 +14,7 @@ import coil.request.ImageRequest
 import coil.request.SuccessResult
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticDrawableIcon
+import com.absinthe.libchecker.domain.statistics.chart.model.StatisticFacetSpec
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticIconRenderMode
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticIconSpec
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticIconTintRole
@@ -43,6 +44,9 @@ internal suspend fun StatisticIconSpec.resolveDrawable(context: Context): Drawab
     }
   }
 }
+
+internal val StatisticFacetSpec.summaryTitle: StatisticTitleSpec
+  get() = shortTitle ?: title
 
 internal fun resolveStatisticTranslation(
   translations: Map<String, String>,

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentation.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentation.kt
@@ -7,6 +7,7 @@ import android.graphics.ColorMatrixColorFilter
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.widget.ImageViewCompat
 import coil.Coil
 import coil.load
@@ -34,19 +35,29 @@ internal fun StatisticTitleSpec.resolve(context: Context): String {
 }
 
 internal suspend fun StatisticIconSpec.resolveDrawable(context: Context): Drawable? {
-  drawable?.let { return ContextCompat.getDrawable(context, it.drawableRes) }
-  val data = localPath?.let(::File) ?: return null
-  return withContext(Dispatchers.IO) {
-    val request = ImageRequest.Builder(context).data(data).build()
-    when (val result = Coil.imageLoader(context).execute(request)) {
-      is SuccessResult -> result.drawable
-      else -> null
+  val resolvedDrawable = drawable?.let { ContextCompat.getDrawable(context, it.drawableRes) }
+    ?: localPath?.let(::File)?.let { data ->
+      withContext(Dispatchers.IO) {
+        val request = ImageRequest.Builder(context).data(data).build()
+        when (val result = Coil.imageLoader(context).execute(request)) {
+          is SuccessResult -> result.drawable
+          else -> null
+        }
+      }
     }
-  }
+    ?: return null
+  return monochromeTintRole?.let { tintRole ->
+    DrawableCompat.wrap(resolvedDrawable.mutate()).also { tintedDrawable ->
+      DrawableCompat.setTint(tintedDrawable, context.getColorByAttr(tintRole.colorAttr))
+    }
+  } ?: resolvedDrawable
 }
 
 internal val StatisticFacetSpec.summaryTitle: StatisticTitleSpec
   get() = shortTitle ?: title
+
+internal val StatisticIconSpec.monochromeTintRole: StatisticIconTintRole?
+  get() = tintRole.takeIf { renderMode == StatisticIconRenderMode.MONOCHROME }
 
 internal fun resolveStatisticTranslation(
   translations: Map<String, String>,
@@ -78,16 +89,14 @@ internal fun ImageView.loadStatisticIcon(
   selected: Boolean,
   grayscale: Boolean = false
 ) {
-  val tint = if (icon.renderMode == StatisticIconRenderMode.MONOCHROME) {
+  val tint = icon.monochromeTintRole?.let { tintRole ->
     val useSelectedAccent = selected && icon.asset != null
     val tintColor = if (useSelectedAccent) {
       context.getColorByAttr(androidx.appcompat.R.attr.colorPrimary)
     } else {
-      context.getColorByAttr(icon.tintRole.colorAttr)
+      context.getColorByAttr(tintRole.colorAttr)
     }
     ColorStateList.valueOf(tintColor)
-  } else {
-    null
   }
   clearColorFilter()
   if (grayscale && tint == null) {

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentation.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentation.kt
@@ -4,9 +4,14 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
+import android.graphics.drawable.Drawable
 import android.widget.ImageView
+import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
+import coil.Coil
 import coil.load
+import coil.request.ImageRequest
+import coil.request.SuccessResult
 import com.absinthe.libchecker.R
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticDrawableIcon
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticIconRenderMode
@@ -18,11 +23,25 @@ import com.absinthe.libchecker.utils.extensions.dp
 import com.absinthe.libchecker.utils.extensions.getColorByAttr
 import java.io.File
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 internal fun StatisticTitleSpec.resolve(context: Context): String {
   resource?.let { return context.getString(it.stringRes) }
   val locale = context.resources.configuration.locales[0]
   return resolveStatisticTranslation(translations, locale)
+}
+
+internal suspend fun StatisticIconSpec.resolveDrawable(context: Context): Drawable? {
+  drawable?.let { return ContextCompat.getDrawable(context, it.drawableRes) }
+  val data = localPath?.let(::File) ?: return null
+  return withContext(Dispatchers.IO) {
+    val request = ImageRequest.Builder(context).data(data).build()
+    when (val result = Coil.imageLoader(context).execute(request)) {
+      is SuccessResult -> result.drawable
+      else -> null
+    }
+  }
 }
 
 internal fun resolveStatisticTranslation(

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/usecase/ValidateStatisticCatalogUseCase.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/chart/usecase/ValidateStatisticCatalogUseCase.kt
@@ -155,6 +155,20 @@ class ValidateStatisticCatalogUseCase {
               ) {
                 errors += "External facet must provide an English title: ${definition.id}: ${facet.id}"
               }
+              facet.shortTitle?.let { shortTitle ->
+                validateTitle(
+                  titleSpec = shortTitle,
+                  statisticId = definition.id,
+                  errors = errors,
+                  maxLength = MAX_FACET_TITLE_LENGTH
+                )
+                if (
+                  definition.source != StatisticSource.BUILTIN &&
+                  shortTitle.translations[DEFAULT_TRANSLATION_LOCALE].isNullOrBlank()
+                ) {
+                  errors += "External facet must provide an English short title: ${definition.id}: ${facet.id}"
+                }
+              }
               validateCondition(
                 condition = facet.condition,
                 statisticId = definition.id,

--- a/app/src/test/kotlin/com/absinthe/libchecker/data/statistics/OfficialStatisticBundleStoreTest.kt
+++ b/app/src/test/kotlin/com/absinthe/libchecker/data/statistics/OfficialStatisticBundleStoreTest.kt
@@ -128,6 +128,7 @@ class OfficialStatisticBundleStoreTest {
             StatisticFacetSpec(
               id = "voip-service-kit",
               title = StatisticTitleSpec(translations = mapOf("en" to "VoIP Service Kit")),
+              shortTitle = StatisticTitleSpec(translations = mapOf("en" to "VoIP")),
               condition = StatisticConditionSpec(
                 evidence = StatisticEvidence.DEX_CLASS,
                 operator = StatisticComparisonOperator.CONTAINS_ANY,
@@ -154,7 +155,9 @@ class OfficialStatisticBundleStoreTest {
     val cached = store.loadCachedStatistics()
 
     assertEquals(listOf("official.capabilities"), installed.map { it.id })
-    assertEquals("voip-service-kit", cached.single().calculation.facets?.items?.single()?.id)
+    val cachedFacet = cached.single().calculation.facets?.items?.single()
+    assertEquals("voip-service-kit", cachedFacet?.id)
+    assertEquals("VoIP", cachedFacet?.shortTitle?.translations?.get("en"))
   }
 
   @Test

--- a/app/src/test/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentationTest.kt
+++ b/app/src/test/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentationTest.kt
@@ -1,5 +1,8 @@
 package com.absinthe.libchecker.domain.statistics.chart.ui
 
+import com.absinthe.libchecker.domain.statistics.chart.model.StatisticConditionSpec
+import com.absinthe.libchecker.domain.statistics.chart.model.StatisticFacetSpec
+import com.absinthe.libchecker.domain.statistics.chart.model.StatisticTitleSpec
 import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -34,6 +37,21 @@ class StatisticPresentationTest {
     )
 
     assertEquals("其他應用程式", result)
+  }
+
+  @Test
+  fun `uses short facet title for summaries and falls back to the full title`() {
+    val fullTitle = StatisticTitleSpec(translations = mapOf("en" to "VoIP Service Kit"))
+    val shortTitle = StatisticTitleSpec(translations = mapOf("en" to "VoIP"))
+    val facet = StatisticFacetSpec(
+      id = "voip-service-kit",
+      title = fullTitle,
+      shortTitle = shortTitle,
+      condition = StatisticConditionSpec()
+    )
+
+    assertEquals(shortTitle, facet.summaryTitle)
+    assertEquals(fullTitle, facet.copy(shortTitle = null).summaryTitle)
   }
 
   @Test

--- a/app/src/test/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentationTest.kt
+++ b/app/src/test/kotlin/com/absinthe/libchecker/domain/statistics/chart/ui/StatisticPresentationTest.kt
@@ -2,9 +2,13 @@ package com.absinthe.libchecker.domain.statistics.chart.ui
 
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticConditionSpec
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticFacetSpec
+import com.absinthe.libchecker.domain.statistics.chart.model.StatisticIconRenderMode
+import com.absinthe.libchecker.domain.statistics.chart.model.StatisticIconSpec
+import com.absinthe.libchecker.domain.statistics.chart.model.StatisticIconTintRole
 import com.absinthe.libchecker.domain.statistics.chart.model.StatisticTitleSpec
 import java.util.Locale
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class StatisticPresentationTest {
@@ -52,6 +56,17 @@ class StatisticPresentationTest {
 
     assertEquals(shortTitle, facet.summaryTitle)
     assertEquals(fullTitle, facet.copy(shortTitle = null).summaryTitle)
+  }
+
+  @Test
+  fun `uses the declared tint role only for monochrome icons`() {
+    val icon = StatisticIconSpec(
+      renderMode = StatisticIconRenderMode.MONOCHROME,
+      tintRole = StatisticIconTintRole.ON_SURFACE
+    )
+
+    assertEquals(StatisticIconTintRole.ON_SURFACE, icon.monochromeTintRole)
+    assertNull(icon.copy(renderMode = StatisticIconRenderMode.ORIGINAL).monochromeTintRole)
   }
 
   @Test

--- a/app/src/test/kotlin/com/absinthe/libchecker/domain/statistics/chart/usecase/ValidateStatisticCatalogUseCaseTest.kt
+++ b/app/src/test/kotlin/com/absinthe/libchecker/domain/statistics/chart/usecase/ValidateStatisticCatalogUseCaseTest.kt
@@ -271,6 +271,7 @@ class ValidateStatisticCatalogUseCaseTest {
             StatisticFacetSpec(
               id = "voip-service-kit",
               title = translatedTitle("VoIP Service Kit"),
+              shortTitle = translatedTitle("VoIP"),
               condition = StatisticConditionSpec(
                 evidence = StatisticEvidence.DEX_CLASS,
                 operator = StatisticComparisonOperator.CONTAINS_ANY,
@@ -301,6 +302,7 @@ class ValidateStatisticCatalogUseCaseTest {
     val facet = StatisticFacetSpec(
       id = "capability",
       title = StatisticTitleSpec(translations = mapOf("zh-Hans" to "能力")),
+      shortTitle = StatisticTitleSpec(translations = mapOf("zh-Hans" to "短能力")),
       condition = StatisticConditionSpec(
         evidence = StatisticEvidence.TARGET_SDK,
         operator = StatisticComparisonOperator.GREATER_THAN_OR_EQUAL,
@@ -323,6 +325,7 @@ class ValidateStatisticCatalogUseCaseTest {
 
     assertTrue(errors.any { it.startsWith("Facets statistic has a duplicate facet id") })
     assertTrue(errors.any { it.startsWith("External facet must provide an English title") })
+    assertTrue(errors.any { it.startsWith("External facet must provide an English short title") })
   }
 
   @Test


### PR DESCRIPTION
- 为图表页的在线规则检测 Bottom Sheet 下的 App List、App Detail 页的在线规则检测 Bottom Sheet 中检测到的规则应用短标题
- 为 AppDetail 页的在线规则检测 BottomSheet 中的 Feat Dialog `setIcon`

![](https://github.com/user-attachments/assets/8b27a8e8-7970-4d26-b2ad-1f0357c0a266)

---

原金标联盟开放能力 PR 在 https://github.com/ArcticFoxPro/LibChecker/tree/old 中保留