### PR TITLE
Reuse runtime-resolved app icon placeholder

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/list/ui/view/AppItemView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/list/ui/view/AppItemView.kt
@@ -34,6 +34,7 @@ import com.absinthe.libchecker.utils.extensions.getResourceIdByAttr
 import com.absinthe.libchecker.utils.extensions.isRtl
 import com.absinthe.libchecker.utils.extensions.tintHighlightText
 import com.absinthe.libchecker.view.AViewGroup
+import com.absinthe.libchecker.view.app.AppIconPlaceholder
 import com.absinthe.libchecker.view.span.CenterAlignImageSpan
 import com.google.android.material.card.MaterialCardView
 import me.zhanghai.android.appiconloader.AppIconLoader
@@ -581,7 +582,7 @@ class AppItemView(
 
     fun newIconPlaceholder(context: Context): Drawable? {
       return iconPlaceholderState?.newDrawable(context.resources)
-        ?: R.mipmap.ic_app_icon_placeholder.getDrawable(context)
+        ?: AppIconPlaceholder.newDrawable(context)
     }
 
     companion object {
@@ -608,7 +609,7 @@ class AppItemView(
           onSurfaceVariantColor = context.getColorByAttr(
             com.google.android.material.R.attr.colorOnSurfaceVariant
           ),
-          iconPlaceholderState = R.mipmap.ic_app_icon_placeholder.getDrawable(context)?.constantState
+          iconPlaceholderState = AppIconPlaceholder.newDrawable(context)?.constantState
         )
       }
     }

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/list/ui/view/SnapshotMenuBSDView.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/list/ui/view/SnapshotMenuBSDView.kt
@@ -19,6 +19,7 @@ import com.absinthe.libchecker.ui.app.BottomSheetRecyclerView
 import com.absinthe.libchecker.ui.app.MenuOptionItem
 import com.absinthe.libchecker.ui.app.MenuOptionItemView
 import com.absinthe.libchecker.utils.extensions.dp
+import com.absinthe.libchecker.view.app.AppIconPlaceholder
 import com.absinthe.libchecker.view.app.IHeaderView
 import com.absinthe.libraries.utils.view.BottomSheetHeaderView
 import com.chad.library.adapter.base.BaseQuickAdapter
@@ -160,7 +161,7 @@ class SnapshotMenuBSDView(context: Context) :
         return child
       }
       removeAllViews()
-      return SnapshotItemView(context).apply {
+      return SnapshotItemView(context, AppIconPlaceholder.resourceId).apply {
         layoutParams = LayoutParams(
           LayoutParams.MATCH_PARENT,
           LayoutParams.WRAP_CONTENT

--- a/app/src/main/kotlin/com/absinthe/libchecker/view/app/AppIconPlaceholder.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/view/app/AppIconPlaceholder.kt
@@ -1,0 +1,18 @@
+package com.absinthe.libchecker.view.app
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import androidx.annotation.DrawableRes
+import com.absinthe.libchecker.R
+import com.absinthe.libchecker.utils.extensions.getDrawable
+
+object AppIconPlaceholder {
+
+  @get:DrawableRes
+  val resourceId: Int
+    get() = R.mipmap.ic_app_icon_placeholder
+
+  fun newDrawable(context: Context): Drawable? {
+    return resourceId.getDrawable(context)
+  }
+}

--- a/app/src/test/kotlin/com/absinthe/libchecker/view/app/AppIconPlaceholderTest.kt
+++ b/app/src/test/kotlin/com/absinthe/libchecker/view/app/AppIconPlaceholderTest.kt
@@ -1,0 +1,15 @@
+package com.absinthe.libchecker.view.app
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppIconPlaceholderTest {
+
+  @Test
+  fun `placeholder resource id is resolved at runtime`() {
+    assertTrue(
+      "Adaptive icon placeholder resource must not be the unresolved zero ID",
+      AppIconPlaceholder.resourceId != 0
+    )
+  }
+}


### PR DESCRIPTION
Avoid const-inlining non-final Android resource IDs to zero so app-list and snapshot demo fallbacks share the masked adaptive icon safely.