### PR TITLE
UI/UX Optimization: Resolving List Scroll Stalling and Navigation Interoperability Regressions

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/app/list/ui/AppListFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/app/list/ui/AppListFragment.kt
@@ -123,7 +123,7 @@ class AppListFragment :
         layoutManager = getSuitableLayoutManagerImpl(resources.configuration)
         borderVisibilityChangedListener =
           BorderView.OnBorderVisibilityChangedListener { top: Boolean, _: Boolean, _: Boolean, _: Boolean ->
-            if (isResumed) {
+            if (isFragmentVisible()) {
               scheduleAppbarLiftingStatus(!top)
             }
           }
@@ -140,8 +140,14 @@ class AppListFragment :
           }
 
           override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            if (dx != 0 || dy != 0) {
+              isSearchTextClearOnce = false
+            }
             if (dx == 0 && dy == 0) {
               // scrolled by dragging scrolling bar
+              if (!isSearchTextClearOnce) {
+                homeViewModel.onAppListUserScrolled()
+              }
               if (!firstScrollFlag) {
                 firstScrollFlag = true
                 return
@@ -149,9 +155,6 @@ class AppListFragment :
               if (delayShowNavigationJob?.isActive == true) {
                 delayShowNavigationJob?.cancel()
                 delayShowNavigationJob = null
-              }
-              if (isFragmentVisible() && !isSearchTextClearOnce && canListScroll(appAdapter.data.size)) {
-                (activity as? INavViewContainer)?.hideNavigationView()
               }
 
               val position = when (layoutManager) {
@@ -227,7 +230,6 @@ class AppListFragment :
 
   override fun onResume() {
     super.onResume()
-    (activity as? IAppBarContainer)?.setLiftOnScrollTargetView(binding.list)
     if (homeViewModel.appListStatus == STATUS_START_INIT) {
       flip(VF_INIT)
       activity?.removeMenuProvider(this)
@@ -368,6 +370,9 @@ class AppListFragment :
     super.onVisibilityChanged(visible)
     if (visible) {
       appAdapter.setSpaceFooterView()
+      (activity as? IAppBarContainer)?.setLiftOnScrollTargetView(binding.list)
+    } else {
+      firstScrollFlag = false
     }
   }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/home/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/home/ui/MainActivity.kt
@@ -38,6 +38,7 @@ import com.absinthe.libchecker.domain.rules.CloudRulesRepository
 import com.absinthe.libchecker.services.IWorkerService
 import com.absinthe.libchecker.services.WorkerService
 import com.absinthe.libchecker.ui.base.BaseActivity
+import com.absinthe.libchecker.ui.base.BaseFragment
 import com.absinthe.libchecker.ui.base.IAppBarContainer
 import com.absinthe.libchecker.ui.base.IListController
 import com.absinthe.libchecker.ui.base.IListControllerHost
@@ -239,6 +240,14 @@ class MainActivity :
             super.onPageSelected(position)
             navView.menu.findItem(HomeDestination.requirePageIndex(position).navigationItemId).isChecked = true
             appViewModel.clearMenuState()
+
+            val fragment = supportFragmentManager.findFragmentByTag("f$position") as? BaseFragment<*>
+            fragment?.onVisibilityChanged(true)
+            (0 until HomeDestination.pageCount).forEach { index ->
+              if (index != position) {
+                (supportFragmentManager.findFragmentByTag("f$index") as? BaseFragment<*>)?.onVisibilityChanged(false)
+              }
+            }
           }
         })
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/list/ui/SnapshotFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/snapshot/list/ui/SnapshotFragment.kt
@@ -225,7 +225,7 @@ class SnapshotFragment :
         layoutManager = getSuitableLayoutManagerImpl(resources.configuration)
         borderVisibilityChangedListener =
           BorderView.OnBorderVisibilityChangedListener { top: Boolean, _: Boolean, _: Boolean, _: Boolean ->
-            if (isResumed) {
+            if (isFragmentVisible()) {
               scheduleAppbarLiftingStatus(!top)
             }
           }
@@ -346,8 +346,6 @@ class SnapshotFragment :
         flip(VF_LOADING)
       }
     }
-
-    (activity as? IAppBarContainer)?.setLiftOnScrollTargetView(binding.list)
 
     if (binding.vfContainer.displayedChild == VF_LOADING) {
       binding.loading.start()
@@ -490,6 +488,7 @@ class SnapshotFragment :
     super.onVisibilityChanged(visible)
     if (visible) {
       adapter.setSpaceFooterView()
+      (activity as? IAppBarContainer)?.setLiftOnScrollTargetView(binding.list)
     }
   }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/reference/ui/LibReferenceFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/domain/statistics/reference/ui/LibReferenceFragment.kt
@@ -87,13 +87,16 @@ class LibReferenceFragment :
         borderDelegate = borderViewDelegate
         borderVisibilityChangedListener =
           BorderView.OnBorderVisibilityChangedListener { top: Boolean, _: Boolean, _: Boolean, _: Boolean ->
-            if (isResumed) {
+            if (isFragmentVisible()) {
               scheduleAppbarLiftingStatus(!top)
             }
           }
         FastScrollerBuilder(this).useMd2Style().build()
         addOnScrollListener(object : RecyclerView.OnScrollListener() {
           override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            if (dx != 0 || dy != 0) {
+              isSearchTextClearOnce = false
+            }
             if (dx == 0 && dy == 0) {
               // scrolled by dragging scrolling bar
               if (!firstScrollFlag) {
@@ -103,9 +106,6 @@ class LibReferenceFragment :
               if (delayShowNavigationJob?.isActive == true) {
                 delayShowNavigationJob?.cancel()
                 delayShowNavigationJob = null
-              }
-              if (isFragmentVisible() && !isSearchTextClearOnce && canListScroll(refAdapter.data.size)) {
-                (activity as? INavViewContainer)?.hideNavigationView()
               }
 
               val position = when (layoutManager) {
@@ -237,7 +237,6 @@ class LibReferenceFragment :
 
   override fun onResume() {
     super.onResume()
-    (activity as? IAppBarContainer)?.setLiftOnScrollTargetView(binding.list)
     if (binding.vfContainer.displayedChild == VF_LOADING) {
       binding.loadingView.loadingView.start()
     }
@@ -405,9 +404,12 @@ class LibReferenceFragment :
     super.onVisibilityChanged(visible)
     if (visible) {
       refAdapter.setSpaceFooterView()
+      (activity as? IAppBarContainer)?.setLiftOnScrollTargetView(binding.list)
       applyReferenceWork(
         libReferenceViewModel.onReferencePageVisible(hasDisplayedReferences = refAdapter.data.isNotEmpty())
       )
+    } else {
+      firstScrollFlag = false
     }
   }
 

--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/base/BaseListControllerFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/base/BaseListControllerFragment.kt
@@ -29,10 +29,6 @@ abstract class BaseListControllerFragment<T : ViewBinding> :
     super.onViewCreated(view, savedInstanceState)
     activity?.addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
     viewLifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
-      override fun onResume(owner: LifecycleOwner) {
-        scheduleAppbarLiftingStatus(getBorderViewDelegate()?.isShowingTopBorder == false)
-      }
-
       override fun onStop(owner: LifecycleOwner) {
         listControllerHost?.clearListController(this@BaseListControllerFragment)
       }
@@ -43,6 +39,7 @@ abstract class BaseListControllerFragment<T : ViewBinding> :
     super.onVisibilityChanged(visible)
     if (visible) {
       listControllerHost?.setListController(this)
+      scheduleAppbarLiftingStatus(getBorderViewDelegate()?.isShowingTopBorder == false)
     }
   }
 


### PR DESCRIPTION
Identified and resolved a series of interaction bugs on the main list pages where scrolling could become unresponsive **("stuck")** after applying filters or returning from background states. The fix involves tightening the synchronization between the **ViewPager2** navigation and the **AppBarLayout** scroll targets, alongside more robust user-interaction detection for fast-scrolling.